### PR TITLE
[Doc] Add CI/CD status badge

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,6 +6,7 @@
 [![中文](https://img.shields.io/badge/language-中文-red.svg)](README.zh-CN.md)
 [![日本語](https://img.shields.io/badge/language-日本語-green.svg)](README.ja.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenBlink/openblink-vscode-extension)
+[![.github/workflows/cicd.yml](https://github.com/OpenBlink/openblink-vscode-extension/actions/workflows/cicd.yml/badge.svg)](https://github.com/OpenBlink/openblink-vscode-extension/actions/workflows/cicd.yml)
 
 Open Blinkの詳細については[こちら](https://github.com/OpenBlink/openblink)をご覧ください。
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![中文](https://img.shields.io/badge/language-中文-red.svg)](README.zh-CN.md)
 [![日本語](https://img.shields.io/badge/language-日本語-green.svg)](README.ja.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenBlink/openblink-vscode-extension)
+[![.github/workflows/cicd.yml](https://github.com/OpenBlink/openblink-vscode-extension/actions/workflows/cicd.yml/badge.svg)](https://github.com/OpenBlink/openblink-vscode-extension/actions/workflows/cicd.yml)
 
 For more information about Open Blink, please visit [here](https://github.com/OpenBlink/openblink).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,7 @@
 [![中文](https://img.shields.io/badge/language-中文-red.svg)](README.zh-CN.md)
 [![日本語](https://img.shields.io/badge/language-日本語-green.svg)](README.ja.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenBlink/openblink-vscode-extension)
+[![.github/workflows/cicd.yml](https://github.com/OpenBlink/openblink-vscode-extension/actions/workflows/cicd.yml/badge.svg)](https://github.com/OpenBlink/openblink-vscode-extension/actions/workflows/cicd.yml)
 
 关于Open Blink的更多信息，请访问[这里](https://github.com/OpenBlink/openblink)。
 


### PR DESCRIPTION
This pull request updates the `README` files in multiple languages to include a badge linking to the project's CI/CD workflow status on GitHub.

Documentation updates:

* Added a CI/CD workflow badge to the English `README.md` file to indicate the build status.
* Added a CI/CD workflow badge to the Japanese `README.ja.md` file to indicate the build status.
* Added a CI/CD workflow badge to the Chinese `README.zh-CN.md` file to indicate the build status.