### PR TITLE
docs: add CI workflow status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenBlink VSCode Extension
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OpenBlink/openblink-vscode-extension)
+[![CI](https://github.com/OpenBlink/openblink-vscode-extension/actions/workflows/ci.yml/badge.svg)](https://github.com/OpenBlink/openblink-vscode-extension/actions/workflows/ci.yml)
 
 **Edit Ruby, save, and your device changes instantly** — wireless embedded development in < 0.1 seconds, with no restart required.
 


### PR DESCRIPTION
This pull request adds a status badge for the CI workflow to the `README.md` file, making it easier to see the current build status directly from the project page.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
