### PR TITLE
Improve build-and-blink workflow and BLE console output

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -52,7 +52,10 @@ graph TB
 
 ## Data Flow: Build & Blink
 
-The currently active `.rb` file in the editor is always used for compilation.
+When the user saves a `.rb` file that is focused in the active editor, an
+`onDidSaveTextDocument` listener triggers the build-and-blink cycle.  A
+concurrency guard (`isBuilding`) prevents overlapping operations — if a build
+is already in progress the new request is silently skipped.
 
 ```mermaid
 sequenceDiagram
@@ -65,8 +68,10 @@ sequenceDiagram
     participant Dev as OpenBlink Device
 
     User->>VSCode: Save active .rb file (Ctrl+S / Cmd+S)
-    VSCode->>Ext: saveAndBuildAndBlink(activeEditor.document.uri)
-    Ext->>Ext: Read active file content
+    VSCode->>Ext: onDidSaveTextDocument(document)
+    Ext->>Ext: Guard: active editor matches saved file?
+    Ext->>Ext: Guard: isBuilding? (skip if true)
+    Ext->>Ext: Read saved file content
     Ext->>Comp: compile(rubyCode)
     Comp->>WASM: FS.writeFile → _main → FS.readFile
     WASM-->>Comp: .mrb bytecode
@@ -84,3 +89,5 @@ sequenceDiagram
 ```
 
 If the device is not connected, compilation still runs and metrics are recorded, but the BLE transfer is skipped with a warning.
+
+Background saves (e.g. `files.autoSave`, format-on-save of non-focused files) do not trigger a build.  The extension uses `onWillSaveTextDocument` to record saves whose reason is `Manual` and ignores all others, ensuring BLE transfers only occur from explicit user action.

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -69,7 +69,6 @@ Below is a reference of all keys used in `package.nls.*.json`. New keys added fo
 | `command.connectDevice` | Connect Device | Legacy connect command |
 | `command.disconnectDevice` | Disconnect Device | Disconnect command |
 | `command.buildAndBlink` | Build & Blink | Compile + transfer |
-| `command.saveAndBuildAndBlink` | Save & Build & Blink | Save + compile + transfer |
 | `command.softReset` | Soft Reset | Device soft reset |
 | `command.selectSourceFile` | Select Source File | Source file picker |
 | `command.selectBoard` | Select Board | Board picker |

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -45,5 +45,7 @@
   "Device Name": "デバイスなまえ",
   "Device ID": "デバイスID",
   "No board selected": "ボードがえらばれていません",
-  "Connection timeout": "せつぞくがタイムアウトしました"
+  "Connection timeout": "せつぞくがタイムアウトしました",
+  "Compiler initialization failed: {0}": "コンパイラのしょきかにしっぱいしました: {0}",
+  "Build already in progress": "ビルドがすでにじっこうちゅうです"
 }

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -45,5 +45,7 @@
   "Device Name": "Device Name",
   "Device ID": "Device ID",
   "No board selected": "No board selected",
-  "Connection timeout": "Connection timeout"
+  "Connection timeout": "Connection timeout",
+  "Compiler initialization failed: {0}": "Compiler initialization failed: {0}",
+  "Build already in progress": "Build already in progress"
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -45,5 +45,7 @@
   "Device Name": "设备名称",
   "Device ID": "设备ID",
   "No board selected": "未选择开发板",
-  "Connection timeout": "连接超时"
+  "Connection timeout": "连接超时",
+  "Compiler initialization failed: {0}": "编译器初始化失败: {0}",
+  "Build already in progress": "构建正在进行中"
 }

--- a/l10n/bundle.l10n.zh-tw.json
+++ b/l10n/bundle.l10n.zh-tw.json
@@ -45,5 +45,7 @@
   "Device Name": "裝置名稱",
   "Device ID": "裝置ID",
   "No board selected": "未選擇開發板",
-  "Connection timeout": "連接逾時"
+  "Connection timeout": "連接逾時",
+  "Compiler initialization failed: {0}": "編譯器初始化失敗: {0}",
+  "Build already in progress": "建置正在進行中"
 }

--- a/package.json
+++ b/package.json
@@ -38,11 +38,6 @@
         "category": "OpenBlink"
       },
       {
-        "command": "openblink.saveAndBuildAndBlink",
-        "title": "%command.saveAndBuildAndBlink%",
-        "category": "OpenBlink"
-      },
-      {
         "command": "openblink.softReset",
         "title": "%command.softReset%",
         "category": "OpenBlink"
@@ -115,14 +110,6 @@
         }
       }
     },
-    "keybindings": [
-      {
-        "command": "openblink.saveAndBuildAndBlink",
-        "key": "ctrl+s",
-        "mac": "cmd+s",
-        "when": "editorTextFocus && resourceExtname == .rb"
-      }
-    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -4,7 +4,6 @@
   "command.connectDevice": "デバイスにつなぐ",
   "command.disconnectDevice": "デバイスからはなれる",
   "command.buildAndBlink": "Build & Blink",
-  "command.saveAndBuildAndBlink": "ほぞんして Build & Blink",
   "command.softReset": "ソフトリセット",
   "command.selectSourceFile": "ソースファイルをえらぶ",
   "command.selectBoard": "ボードをえらぶ",

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,7 +4,6 @@
   "command.connectDevice": "Connect Device",
   "command.disconnectDevice": "Disconnect Device",
   "command.buildAndBlink": "Build & Blink",
-  "command.saveAndBuildAndBlink": "Save & Build & Blink",
   "command.softReset": "Soft Reset",
   "command.selectSourceFile": "Select Source File",
   "command.selectBoard": "Select Board",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -4,7 +4,6 @@
   "command.connectDevice": "连接设备",
   "command.disconnectDevice": "断开设备",
   "command.buildAndBlink": "Build & Blink",
-  "command.saveAndBuildAndBlink": "保存并 Build & Blink",
   "command.softReset": "软复位",
   "command.selectSourceFile": "选择源文件",
   "command.selectBoard": "选择开发板",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -4,7 +4,6 @@
   "command.connectDevice": "連接裝置",
   "command.disconnectDevice": "中斷連接",
   "command.buildAndBlink": "Build & Blink",
-  "command.saveAndBuildAndBlink": "儲存並 Build & Blink",
   "command.softReset": "軟體重設",
   "command.selectSourceFile": "選擇原始檔",
   "command.selectBoard": "選擇開發板",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,7 +120,12 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   bleManager.onConsoleOutput((message) => {
-    ui.log(`[DEVICE] ${message}`);
+    for (const line of message.split('\n')) {
+      const trimmed = line.replace(/\r$/, '');
+      if (trimmed.length > 0) {
+        ui.log(`[DEVICE] ${trimmed}`);
+      }
+    }
   });
 
   bleManager.onLog((message) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,10 @@ let boardReferenceProvider: ui.BoardReferenceTreeProvider;
 let currentSourceFile: string;
 /** @brief Active program slot on the target device (1 or 2). */
 let currentSlot: number;
+/** @brief Guard flag to prevent overlapping build-and-blink operations. */
+let isBuilding = false;
+/** @brief URIs of files being saved manually (not by auto-save). */
+const pendingManualSave = new Set<string>();
 
 /**
  * @brief Extension activation entry point.
@@ -41,6 +45,12 @@ let currentSlot: number;
  * board definitions, and the mruby WASM compiler.  Restores saved devices
  * from `globalState` and registers all user-facing commands, including
  * scan start/stop, device connection by ID, and device forget.
+ *
+ * Registers an `onDidSaveTextDocument` listener that automatically triggers
+ * a build-and-blink cycle when the user saves a `.rb` file that is currently
+ * focused in the active editor.  Background saves (e.g. `files.autoSave`,
+ * format-on-save of non-focused files) are ignored to prevent unintended
+ * BLE transfers.
  *
  * Also registers a `onDidChangeConfiguration` listener so that changes to
  * `openblink.sourceFile`, `openblink.slot`, and `openblink.board` made
@@ -154,6 +164,40 @@ export function activate(context: vscode.ExtensionContext) {
     ui.log(`[SYSTEM] Compiler initialization failed: ${msg}`);
     vscode.window.showErrorMessage(l10n.t('Compiler initialization failed: {0}', msg));
   });
+
+  // Auto build-and-blink when the user manually saves a .rb file that is
+  // currently focused in the editor.  Ignores background saves (e.g.
+  // files.autoSave, format-on-save of non-focused files) to avoid
+  // unintended BLE transfers.
+  //
+  // onWillSaveTextDocument fires *before* the save and exposes the
+  // save reason (Manual vs AfterDelay/FocusOut).  We record manual
+  // saves in pendingManualSave and check it in onDidSaveTextDocument.
+  context.subscriptions.push(
+    vscode.workspace.onWillSaveTextDocument((e) => {
+      if (e.reason === vscode.TextDocumentSaveReason.Manual) {
+        const key = e.document.uri.toString();
+        pendingManualSave.add(key);
+        // Safety: remove stale entry if onDidSaveTextDocument never fires
+        // (e.g. save fails due to a disk error).
+        setTimeout(() => { pendingManualSave.delete(key); }, 5000);
+      }
+    }),
+    vscode.workspace.onDidSaveTextDocument(async (document) => {
+      const key = document.uri.toString();
+      if (!pendingManualSave.delete(key)) { return; }
+      if (!document.fileName.endsWith('.rb')) { return; }
+      const activeDoc = vscode.window.activeTextEditor?.document;
+      if (!activeDoc || activeDoc.uri.toString() !== key) { return; }
+      try {
+        await buildAndBlink(context, document.uri, { silent: true });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        ui.log(`[SYSTEM] Build error: ${msg}`);
+        vscode.window.showErrorMessage(msg);
+      }
+    }),
+  );
 
   // Listen for configuration changes
   context.subscriptions.push(
@@ -303,20 +347,6 @@ export function activate(context: vscode.ExtensionContext) {
       }
     }),
 
-    vscode.commands.registerCommand('openblink.saveAndBuildAndBlink', async () => {
-      try {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) { return; }
-        if (!editor.document.fileName.endsWith('.rb')) { return; }
-        await editor.document.save();
-        await buildAndBlink(context, editor.document.uri);
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        ui.log(`[SYSTEM] Build error: ${msg}`);
-        vscode.window.showErrorMessage(msg);
-      }
-    }),
-
     vscode.commands.registerCommand('openblink.softReset', async () => {
       const programChar = bleManager.getProgramCharacteristic();
       if (!bleManager.isConnected || !programChar) {
@@ -391,6 +421,35 @@ export function activate(context: vscode.ExtensionContext) {
 /**
  * @brief Compile the given Ruby source file and transfer the bytecode over BLE.
  *
+ * Acts as a concurrency guard around {@link buildAndBlinkInner}.  If a build
+ * is already in progress, the call is silently skipped to prevent overlapping
+ * BLE transfers that could corrupt the protocol stream.
+ *
+ * @param context    Extension context (unused here but kept for API symmetry).
+ * @param sourceUri  URI of the Ruby source file to compile.
+ * @param options    Optional settings.  When `silent` is true, the concurrency
+ *                   skip does not show a user-facing warning (used for
+ *                   auto-triggered builds from the save listener).
+ */
+async function buildAndBlink(context: vscode.ExtensionContext, sourceUri: vscode.Uri, options?: { silent?: boolean }): Promise<void> {
+  if (isBuilding) {
+    ui.log('[SYSTEM] Build already in progress, skipping.');
+    if (!options?.silent) {
+      vscode.window.showWarningMessage(l10n.t('Build already in progress'));
+    }
+    return;
+  }
+  isBuilding = true;
+  try {
+    await buildAndBlinkInner(context, sourceUri);
+  } finally {
+    isBuilding = false;
+  }
+}
+
+/**
+ * @brief Inner implementation of build-and-blink.
+ *
  * Reads the source file, compiles it with mrbc, and (if a device is
  * connected) sends the resulting bytecode to the selected program slot.
  * Updates diagnostics, metrics, and the status bar accordingly.
@@ -398,7 +457,7 @@ export function activate(context: vscode.ExtensionContext) {
  * @param context    Extension context (unused here but kept for API symmetry).
  * @param sourceUri  URI of the Ruby source file to compile.
  */
-async function buildAndBlink(context: vscode.ExtensionContext, sourceUri: vscode.Uri): Promise<void> {
+async function buildAndBlinkInner(context: vscode.ExtensionContext, sourceUri: vscode.Uri): Promise<void> {
   try {
     await vscode.workspace.fs.stat(sourceUri);
   } catch {


### PR DESCRIPTION
## Summary

Improves the build-and-blink development workflow and fixes BLE console output formatting.

## Changes

### Refactor: Replace `saveAndBuildAndBlink` command with automatic build on manual save

- Remove the explicit `openblink.saveAndBuildAndBlink` command and its `Ctrl+S` / `Cmd+S` keybinding
- Add `onWillSaveTextDocument` + `onDidSaveTextDocument` listeners that automatically trigger build-and-blink when the user **manually** saves a `.rb` file focused in the active editor
- Ignore background saves (e.g. `files.autoSave`, format-on-save of non-focused files) to prevent unintended BLE transfers
- Add an `isBuilding` concurrency guard (`buildAndBlink` → `buildAndBlinkInner`) to prevent overlapping BLE transfers that could corrupt the protocol stream
- Remove related i18n entries (`command.saveAndBuildAndBlink`) from all `package.nls.*.json` and `bundle.l10n.*.json` files

### Fix: Strip trailing newlines from BLE console output

- Split multi-line BLE console messages by `\n`, trim trailing `\r`, and skip empty lines before logging each line individually

## Motivation

The previous `Cmd+S` keybinding override could conflict with VS Code's native save behavior and was surprising to some users. The new approach integrates more naturally with the editor's save lifecycle while still providing a seamless build experience. The concurrency guard prevents protocol corruption when saves happen in quick succession.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
