### PR TITLE
feat: OpenBlink MCP (Model Context Protocol) integration for AI agent access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ extract/
 .DS_Store
 Thumbs.db
 
+# MCP IPC directory (runtime state, not tracked)
+.openblink/
+
 # User workspace files (for testing)
 app.rb
 *.mrb

--- a/.windsurf/hooks.json
+++ b/.windsurf/hooks.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "post_write_code": [
+      {
+        "command": "bash .windsurf/hooks/post_write_rb.sh",
+        "show_output": false
+      }
+    ]
+  }
+}

--- a/.windsurf/hooks/post_write_rb.sh
+++ b/.windsurf/hooks/post_write_rb.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# post_write_code hook for OpenBlink — Auto-trigger Build & Blink
+#
+# When Cascade edits a .rb file, this hook creates a trigger file that the
+# OpenBlink extension picks up via FileSystemWatcher and runs Build & Blink.
+#
+# Input: JSON on stdin with tool_info.file_path
+
+input=$(cat)
+file_path=$(echo "$input" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"\(.*\)"/\1/')
+
+# Only trigger for .rb files
+if [[ "$file_path" != *.rb ]]; then
+  exit 0
+fi
+
+# Determine workspace root (directory containing .windsurf/)
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+workspace_root="$(cd "$script_dir/../.." && pwd)"
+
+# Create trigger file for the extension to pick up
+trigger_dir="$workspace_root/.openblink"
+mkdir -p "$trigger_dir"
+
+request_id="hook_$(date +%s)_$$"
+relative_path="${file_path#$workspace_root/}"
+
+# Escape backslashes and double quotes for safe JSON embedding
+escaped_path=$(printf '%s' "$relative_path" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+printf '{\n  "file": "%s",\n  "requestId": "%s"\n}\n' "$escaped_path" "$request_id" > "$trigger_dir/trigger.json"
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ OpenBlink VSCode Extension brings [OpenBlink](https://github.com/OpenBlink/openb
 - **Metrics** — Compile time, transfer time, and program size with min/avg/max statistics in the TreeView
 - **Multi-language UI** — English, やさしい日本語, 简体中文, 繁體中文
 - **AI-friendly** — Structured `[COMPILE]`/`[TRANSFER]`/`[DEVICE]`/`[BLE]` output for Windsurf Cascade integration
+- **MCP Integration** — Built-in [Model Context Protocol](https://modelcontextprotocol.io/) server exposes Build & Blink, device info, console output, metrics, and board reference as AI agent tools (Windsurf, VS Code Copilot, Cursor, Cline), with a dedicated **MCP Status** sidebar view showing connection activity and build results
 
 ## Supported Platforms
 
@@ -63,6 +64,7 @@ The currently active `.rb` file in the editor is always the one that gets compil
 - [Build System](doc/build-system.md) — Emscripten / mrbc WASM build instructions
 - [Compiler](doc/compiler.md) — mrbc WASM compiler internals
 - [Board Configuration](doc/board-configuration.md) — How to add new board definitions
+- [MCP Integration](doc/mcp-integration.md) — AI agent setup for Windsurf, VS Code Copilot, Cursor, and Cline
 - [Internationalization](doc/i18n.md) — Multi-language support guide
 - [Contributing](doc/contributing.md) — Development environment setup
 - [Security](SECURITY.md) — Security policy and dependency audit

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -14,6 +14,11 @@ graph TB
         BLE["ble-manager.ts<br/>BLE Scan & Connection Manager"]
         PROTO["protocol.ts<br/>OpenBlink Protocol"]
         BOARD["board-manager.ts<br/>Board Configuration"]
+        BRIDGE["mcp-bridge.ts<br/>File-based IPC"]
+    end
+
+    subgraph "MCP Server (separate process)"
+        MCP["mcp-server.ts<br/>stdio transport"]
     end
 
     subgraph "WASM Runtime"
@@ -24,11 +29,16 @@ graph TB
         DEV["OpenBlink Device<br/>(mruby/c VM)"]
     end
 
+    subgraph "AI Agent"
+        AI["Cascade / Copilot /<br/>Cursor / Cline"]
+    end
+
     EXT --> UI
     EXT --> DEV_TV
     EXT --> COMP
     EXT --> BLE
     EXT --> BOARD
+    EXT --> BRIDGE
     BLE -->|onScanningStateChanged<br/>onDeviceDiscovered| DEV_TV
     BLE -->|onConnectionStateChanged| DEV_TV
     COMP --> MRBC
@@ -36,6 +46,8 @@ graph TB
     PROTO --> DEV
     DEV -->|Console Notifications| BLE
     BLE -->|Console Output| UI
+    BRIDGE <-->|.openblink/ files| MCP
+    AI <-->|MCP protocol| MCP
 ```
 
 ## Module Responsibilities
@@ -47,7 +59,9 @@ graph TB
 | BLE Manager | `ble-manager.ts` | Device scan (`startScan`/`stopScan`), connect (`connectById`), disconnect, reconnect, MTU negotiation with floor guard |
 | Protocol | `protocol.ts` | OpenBlink BLE protocol (D/P/L/R commands), CRC16, input validation (size/slot/MTU) |
 | Board Manager | `board-manager.ts` | Board configurations with runtime JSON validation, sample code, references (defaults to Generic board) |
-| UI Manager | `ui-manager.ts` | Output Channel, Status Bar, Diagnostics, TreeView providers (Tasks, DeviceInfo, Metrics, **Devices**, BoardReference) |
+| UI Manager | `ui-manager.ts` | Output Channel, Status Bar, Diagnostics, TreeView providers (Tasks, DeviceInfo, Metrics, **Devices**, BoardReference, **McpStatus**), console ring buffer |
+| MCP Bridge | `mcp-bridge.ts` | File-based IPC between extension and MCP server (debounced `status.json`, `openblink-console.log`, `trigger.json`, `result.json`) |
+| MCP Server | `mcp-server.ts` | Standalone stdio MCP server exposing 5 tools (`build_and_blink`, `get_device_info`, `get_console_output`, `get_metrics`, `get_board_reference`) |
 | Types | `types.ts` | Shared type definitions, BLE constants (`MIN_USABLE_MTU`, `CHARACTERISTIC_DISCOVERY_TIMEOUT`, etc.), `SavedDevice` |
 
 ## Data Flow: Build & Blink
@@ -91,3 +105,41 @@ sequenceDiagram
 If the device is not connected, compilation still runs and metrics are recorded, but the BLE transfer is skipped with a warning.
 
 Background saves (e.g. `files.autoSave`, format-on-save of non-focused files) do not trigger a build.  The extension uses `onWillSaveTextDocument` to record saves whose reason is `Manual` and ignores all others, ensuring BLE transfers only occur from explicit user action.
+
+## Data Flow: MCP Integration
+
+The MCP server runs as a separate stdio-based Node.js process, launched by the IDE's MCP client.  It communicates with the extension through JSON files in the `.openblink/` directory (file-based IPC).
+
+```mermaid
+sequenceDiagram
+    participant AI as AI Agent
+    participant MCP as mcp-server.ts
+    participant FS as .openblink/ files
+    participant Ext as extension.ts
+    participant Bridge as mcp-bridge.ts
+
+    Note over Ext,Bridge: Extension writes state on events
+    Ext->>Bridge: updateConnectionStatus / updateMetricsStatus
+    Bridge->>FS: status.json (debounced 1s)
+    Ext->>Bridge: scheduleConsoleWrite
+    Bridge->>FS: openblink-console.log (debounced 2s)
+
+    Note over AI,MCP: AI reads device info
+    AI->>MCP: get_device_info()
+    MCP->>FS: read status.json
+    FS-->>MCP: connection state, metrics
+    MCP-->>AI: formatted response
+
+    Note over AI,Ext: AI triggers Build & Blink
+    AI->>MCP: build_and_blink(file: "app.rb")
+    MCP->>FS: write trigger.json
+    FS-->>Ext: FileSystemWatcher fires
+    Ext->>Ext: buildAndBlink()
+    Ext->>FS: write result.json
+    FS-->>MCP: read result.json (polling)
+    MCP-->>AI: build outcome
+```
+
+The `openblink.mcp.enabled` setting (default `true`) controls whether the MCP bridge writes IPC files and watches for triggers.  When disabled, no disk I/O occurs and the MCP server definition provider returns an empty array.  Existing IPC files are left on disk but become stale.
+
+For Windsurf, a Cascade Hook (`.windsurf/hooks.json` → `post_write_code`) automatically creates a `trigger.json` when Cascade edits a `.rb` file, providing transparent Build & Blink without explicit MCP tool calls.

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -70,6 +70,8 @@ src/
 ├── board-manager.ts    # Board configurations with runtime JSON validation
 ├── ui-manager.ts       # Output Channel, Status Bar, Diagnostics, TreeView providers
 │                       #   (Tasks, DeviceInfo, Metrics, Devices, BoardReference)
+├── mcp-bridge.ts       # File-based IPC between extension and MCP server
+├── mcp-server.ts       # Standalone stdio MCP server (5 tools for AI agents)
 └── types.ts            # Shared type definitions, BLE constants, SavedDevice
 ```
 

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -76,11 +76,16 @@ Below is a reference of all keys used in `package.nls.*.json`. New keys added fo
 | ✱ `command.scanDevices` | Scan Devices | Start BLE scan |
 | ✱ `command.stopScan` | Stop Scan | Stop BLE scan |
 | ✱ `command.forgetDevice` | Forget Device | Remove saved device |
+| `command.setupMcp` | Setup MCP Server | Generate MCP configuration snippet |
 | ✱ `view.devices` | Devices | Devices TreeView title |
 | `view.tasks` | Tasks | Tasks TreeView title |
 | `view.deviceInfo` | Device Info | Device info TreeView title |
 | `view.metrics` | Metrics | Metrics TreeView title |
 | `view.boardReference` | Board Reference | Board reference TreeView title |
+| `config.slot` | Program slot number (1 or 2) | Default slot setting |
+| `config.sourceFile` | Ruby source file to compile | Default source file path |
+| `config.board` | Target board name | Default board selection |
+| `config.mcp.enabled` | Enable MCP integration | MCP on/off toggle |
 
 ## Board References
 

--- a/doc/mcp-integration.md
+++ b/doc/mcp-integration.md
@@ -1,0 +1,131 @@
+# MCP Integration
+
+This document describes the Model Context Protocol (MCP) integration in the
+OpenBlink VS Code Extension, which enables AI agents to interact with
+OpenBlink devices programmatically.
+
+## Overview
+
+The extension ships a built-in MCP server (`out/mcp-server.js`) that exposes
+five tools to any MCP-compatible AI agent:
+
+| Tool | Description |
+|------|-------------|
+| `build_and_blink` | Compile a `.rb` file and transfer the bytecode via BLE |
+| `get_device_info` | Get BLE connection state, device name, ID, and MTU |
+| `get_console_output` | Get recent device console output (up to 100 lines) |
+| `get_metrics` | Get compile/transfer time and program size statistics |
+| `get_board_reference` | Get the selected board's API reference (Markdown) |
+
+## Supported IDEs
+
+| IDE | Discovery | Setup |
+|-----|-----------|-------|
+| **VS Code Copilot** | Automatic via `mcpServerDefinitionProviders` | None — available in Agent Mode after installation |
+| **Windsurf Cascade** | Manual + auto-trigger via Cascade Hook | Add to `~/.codeium/windsurf/mcp_config.json` |
+| **Cursor** | Manual | Add to Cursor MCP settings |
+| **Cline** | Manual | Add to Cline MCP settings |
+
+## Setup
+
+### VS Code Copilot (Automatic)
+
+No setup required. When the extension is installed, the MCP server is
+automatically registered with VS Code Copilot's Agent Mode.
+
+### Windsurf / Cursor / Cline (Manual)
+
+Run the command **OpenBlink: Setup MCP Server** from the Command Palette
+(`Ctrl+Shift+P` / `Cmd+Shift+P`). This generates a JSON snippet that you
+can copy into your IDE's MCP configuration file.
+
+Alternatively, add the following to your MCP config manually:
+
+```json
+{
+  "mcpServers": {
+    "openblink": {
+      "command": "node",
+      "args": ["/path/to/extension/out/mcp-server.js"],
+      "env": {
+        "OPENBLINK_WORKSPACE": "/path/to/your/workspace"
+      }
+    }
+  }
+}
+```
+
+Replace the paths with the actual paths on your system. The `Setup MCP Server`
+command fills these in automatically.
+
+### Windsurf Cascade Hook (Automatic Build & Blink)
+
+The extension includes a Cascade Hook (`.windsurf/hooks.json`) that
+automatically triggers Build & Blink whenever Cascade edits a `.rb` file.
+This provides a transparent experience — Cascade simply edits Ruby code and
+the device updates instantly, without needing to explicitly call the
+`build_and_blink` MCP tool.
+
+To use this, copy the `.windsurf/` directory to your project root:
+
+```
+.windsurf/
+  hooks.json
+  hooks/
+    post_write_rb.sh
+```
+
+## MCP Status View
+
+The **MCP Status** view in the OpenBlink sidebar displays real-time information
+about the MCP integration:
+
+| Item | Description |
+|------|-------------|
+| **MCP: Enabled/Disabled** | Current integration state (click to open settings) |
+| **Status File** | Last time `status.json` was written |
+| **Console Log** | Last time `openblink-console.log` was written |
+| **Last Request** | Timestamp and request ID of the last MCP build trigger |
+| **Last Result** | Success/Failed status with timestamp (hover for error details) |
+
+When MCP is disabled, only the enabled/disabled status is shown.
+
+All MCP-related events are logged to the OpenBlink Output Channel with the
+`[MCP]` prefix for easy filtering.
+
+## Configuration
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `openblink.mcp.enabled` | boolean | `true` | Enable/disable MCP integration |
+
+When disabled:
+- No IPC files are written to `.openblink/`
+- The trigger file watcher is stopped
+- The MCP server definition provider returns an empty array
+- Changes take effect immediately without reload
+
+## Architecture
+
+The extension and MCP server run as separate processes, communicating through
+JSON files in the `.openblink/` directory at the workspace root:
+
+```
+.openblink/
+  status.json    ← Extension writes (debounced 1s): connection, metrics, board
+  openblink-console.log  ← Extension writes (debounced 2s): last 100 device log lines
+  trigger.json   → MCP server writes: build request
+  result.json    ← Extension writes: build outcome
+```
+
+### Performance
+
+- `status.json` is only written on significant events (connection changes,
+  build completions) with a 1-second debounce
+- `openblink-console.log` is written with a 2-second debounce, regardless of how
+  frequently the device produces output
+- The MCP server only reads files when a tool is invoked (no polling)
+- When MCP is disabled, zero disk I/O occurs
+
+See [Architecture](architecture.md) for the full system diagram including the
+MCP data flow.

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -47,5 +47,14 @@
   "No board selected": "ボードがえらばれていません",
   "Connection timeout": "せつぞくがタイムアウトしました",
   "Compiler initialization failed: {0}": "コンパイラのしょきかにしっぱいしました: {0}",
-  "Build already in progress": "ビルドがすでにじっこうちゅうです"
+  "Build already in progress": "ビルドがすでにじっこうちゅうです",
+  "Copy this MCP server configuration to your IDE's MCP config file.": "この MCP サーバーのせっていを IDE の MCP せっていファイルにコピーしてください。",
+  "Enabled": "ゆうこう",
+  "Disabled": "むこう",
+  "Status File": "ステータスファイル",
+  "Console Log": "コンソールログ",
+  "Last Request": "さいごのリクエスト",
+  "Last Result": "さいごのけっか",
+  "Success": "せいこう",
+  "Failed": "しっぱい"
 }

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -47,5 +47,14 @@
   "No board selected": "No board selected",
   "Connection timeout": "Connection timeout",
   "Compiler initialization failed: {0}": "Compiler initialization failed: {0}",
-  "Build already in progress": "Build already in progress"
+  "Build already in progress": "Build already in progress",
+  "Copy this MCP server configuration to your IDE's MCP config file.": "Copy this MCP server configuration to your IDE's MCP config file.",
+  "Enabled": "Enabled",
+  "Disabled": "Disabled",
+  "Status File": "Status File",
+  "Console Log": "Console Log",
+  "Last Request": "Last Request",
+  "Last Result": "Last Result",
+  "Success": "Success",
+  "Failed": "Failed"
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -47,5 +47,14 @@
   "No board selected": "未选择开发板",
   "Connection timeout": "连接超时",
   "Compiler initialization failed: {0}": "编译器初始化失败: {0}",
-  "Build already in progress": "构建正在进行中"
+  "Build already in progress": "构建正在进行中",
+  "Copy this MCP server configuration to your IDE's MCP config file.": "将此 MCP 服务器配置复制到您 IDE 的 MCP 配置文件中。",
+  "Enabled": "已启用",
+  "Disabled": "已禁用",
+  "Status File": "状态文件",
+  "Console Log": "控制台日志",
+  "Last Request": "最近请求",
+  "Last Result": "最近结果",
+  "Success": "成功",
+  "Failed": "失败"
 }

--- a/l10n/bundle.l10n.zh-tw.json
+++ b/l10n/bundle.l10n.zh-tw.json
@@ -47,5 +47,14 @@
   "No board selected": "未選擇開發板",
   "Connection timeout": "連接逾時",
   "Compiler initialization failed: {0}": "編譯器初始化失敗: {0}",
-  "Build already in progress": "建置正在進行中"
+  "Build already in progress": "建置正在進行中",
+  "Copy this MCP server configuration to your IDE's MCP config file.": "將此 MCP 伺服器設定複製到您 IDE 的 MCP 設定檔中。",
+  "Enabled": "已啟用",
+  "Disabled": "已停用",
+  "Status File": "狀態檔案",
+  "Console Log": "控制台日誌",
+  "Last Request": "最近請求",
+  "Last Result": "最近結果",
+  "Success": "成功",
+  "Failed": "失敗"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@abandonware/noble": "^1.9.2-26",
-        "@vscode/l10n": "^0.0.18"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@vscode/l10n": "^0.0.18",
+        "zod": "^3.25.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -444,6 +446,18 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -620,6 +634,63 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -713,7 +784,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1963,6 +2033,53 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2027,7 +2144,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2305,6 +2421,46 @@
         "node": ">= 6"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2452,6 +2608,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/c8": {
       "version": "10.1.3",
       "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
@@ -2537,7 +2702,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2551,7 +2715,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2904,12 +3067,52 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/copy-webpack-plugin": {
       "version": "14.0.0",
@@ -2955,11 +3158,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3135,6 +3354,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3218,7 +3446,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3263,6 +3490,12 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
@@ -3276,6 +3509,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -3386,7 +3628,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3396,7 +3637,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3413,7 +3653,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3447,6 +3686,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3686,6 +3931,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -3694,6 +3948,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expand-template": {
@@ -3714,11 +3989,96 @@
       "license": "Apache-2.0",
       "optional": true
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3756,7 +4116,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3823,6 +4182,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3907,6 +4287,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -3969,7 +4367,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4054,7 +4451,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4079,7 +4475,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4207,7 +4602,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4237,7 +4631,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4273,7 +4666,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4290,6 +4682,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -4351,6 +4752,26 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause",
       "optional": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -4514,7 +4935,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -4540,9 +4960,17 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-binary-path": {
@@ -4705,6 +5133,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -4745,7 +5179,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -4891,6 +5324,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4929,8 +5371,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5311,7 +5758,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5323,6 +5769,27 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -6066,7 +6533,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6075,7 +6541,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6084,12 +6549,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -6412,6 +6888,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6436,7 +6921,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6472,6 +6956,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "6.0.0",
@@ -6511,6 +7005,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -6662,6 +7165,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pseudo-localization": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/pseudo-localization/-/pseudo-localization-2.4.0.tgz",
@@ -6728,7 +7244,6 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -6769,6 +7284,46 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {
@@ -6921,7 +7476,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7079,6 +7633,22 @@
         "node": "*"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -7141,7 +7711,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -7209,6 +7778,57 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
@@ -7217,6 +7837,25 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-blocking": {
@@ -7232,6 +7871,12 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -7250,7 +7895,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7263,7 +7907,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7273,7 +7916,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7293,7 +7935,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7310,7 +7951,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7329,7 +7969,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7557,6 +8196,15 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/stdin-discarder": {
@@ -8136,6 +8784,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -8232,6 +8889,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-rest-client": {
@@ -8340,6 +9036,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -8445,6 +9150,15 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/version-range": {
@@ -8676,7 +9390,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8824,8 +9537,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
@@ -8961,6 +9673,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
         "title": "%command.forgetDevice%",
         "category": "OpenBlink",
         "icon": "$(trash)"
+      },
+      {
+        "command": "openblink.setupMcp",
+        "title": "%command.setupMcp%",
+        "category": "OpenBlink"
       }
     ],
     "configuration": {
@@ -107,9 +112,20 @@
           "type": "string",
           "default": "",
           "description": "%config.board%"
+        },
+        "openblink.mcp.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "%config.mcp.enabled%"
         }
       }
     },
+    "mcpServerDefinitionProviders": [
+      {
+        "id": "openblink.mcpServer",
+        "label": "OpenBlink"
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {
@@ -140,6 +156,10 @@
         {
           "id": "openblink-board-reference",
           "name": "%view.boardReference%"
+        },
+        {
+          "id": "openblink-mcp-status",
+          "name": "%view.mcpStatus%"
         }
       ]
     },
@@ -205,6 +225,8 @@
   },
   "dependencies": {
     "@abandonware/noble": "^1.9.2-26",
-    "@vscode/l10n": "^0.0.18"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@vscode/l10n": "^0.0.18",
+    "zod": "^3.25.0"
   }
 }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -18,5 +18,8 @@
   "view.tasks": "タスク",
   "view.deviceInfo": "デバイスじょうほう",
   "view.metrics": "メトリクス",
-  "view.boardReference": "ボードリファレンス"
+  "view.boardReference": "ボードリファレンス",
+  "command.setupMcp": "MCP サーバーをセットアップ",
+  "config.mcp.enabled": "MCP (Model Context Protocol) とうごうを ON にする — AI エージェントが Build & Blink、デバイスじょうほう、コンソール出力、メトリクス、ボードリファレンスにアクセスできるようにする",
+  "view.mcpStatus": "MCP ステータス"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -18,5 +18,8 @@
   "view.tasks": "Tasks",
   "view.deviceInfo": "Device Info",
   "view.metrics": "Metrics",
-  "view.boardReference": "Board Reference"
+  "view.boardReference": "Board Reference",
+  "command.setupMcp": "Setup MCP Server",
+  "config.mcp.enabled": "Enable MCP (Model Context Protocol) integration for AI agent access to Build & Blink, device info, console output, metrics, and board reference",
+  "view.mcpStatus": "MCP Status"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -18,5 +18,8 @@
   "view.tasks": "任务",
   "view.deviceInfo": "设备信息",
   "view.metrics": "指标",
-  "view.boardReference": "开发板参考"
+  "view.boardReference": "开发板参考",
+  "command.setupMcp": "设置 MCP 服务器",
+  "config.mcp.enabled": "启用 MCP (Model Context Protocol) 集成，允许 AI 代理访问 Build & Blink、设备信息、控制台输出、指标和开发板参考",
+  "view.mcpStatus": "MCP 状态"
 }

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -18,5 +18,8 @@
   "view.tasks": "工作",
   "view.deviceInfo": "裝置資訊",
   "view.metrics": "指標",
-  "view.boardReference": "開發板參考"
+  "view.boardReference": "開發板參考",
+  "command.setupMcp": "設定 MCP 伺服器",
+  "config.mcp.enabled": "啟用 MCP (Model Context Protocol) 整合，允許 AI 代理存取 Build & Blink、裝置資訊、控制台輸出、指標和開發板參考",
+  "view.mcpStatus": "MCP 狀態"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { initCompiler, compile, parseDiagnostics } from './compiler';
 import { sendFirmware, sendReset } from './protocol';
 import * as boardManager from './board-manager';
 import * as ui from './ui-manager';
+import * as mcpBridge from './mcp-bridge';
 import { BLE_CONSTANTS, MetricsData, SavedDevice } from './types';
 
 /** @brief globalState key for persisted saved-device list. */
@@ -27,6 +28,8 @@ let deviceInfoProvider: ui.DeviceInfoTreeProvider;
 let metricsProvider: ui.MetricsTreeProvider;
 /** @brief Sidebar tree-view provider for selected board's API reference. */
 let boardReferenceProvider: ui.BoardReferenceTreeProvider;
+/** @brief Sidebar tree-view provider for MCP integration status. */
+let mcpStatusProvider: ui.McpStatusTreeProvider;
 /** @brief Workspace-relative path of the Ruby source file to compile. */
 let currentSourceFile: string;
 /** @brief Active program slot on the target device (1 or 2). */
@@ -81,6 +84,7 @@ export function activate(context: vscode.ExtensionContext) {
   deviceInfoProvider = new ui.DeviceInfoTreeProvider();
   metricsProvider = new ui.MetricsTreeProvider();
   boardReferenceProvider = new ui.BoardReferenceTreeProvider();
+  mcpStatusProvider = new ui.McpStatusTreeProvider();
 
   // Initialize BLE manager
   bleManager = new BleManager();
@@ -99,6 +103,14 @@ export function activate(context: vscode.ExtensionContext) {
       mtu: bleManager.negotiatedMTU,
     });
     devicesProvider.updateConnection(state, bleManager.deviceId);
+
+    // Update MCP bridge with connection state
+    mcpBridge.updateConnectionStatus(
+      state,
+      bleManager.deviceName,
+      bleManager.deviceId,
+      bleManager.negotiatedMTU,
+    );
 
     // Auto-save device on successful connection
     if (state === 'connected' && bleManager.deviceId) {
@@ -124,8 +136,10 @@ export function activate(context: vscode.ExtensionContext) {
       const trimmed = line.replace(/\r$/, '');
       if (trimmed.length > 0) {
         ui.log(`[DEVICE] ${trimmed}`);
+        ui.appendConsoleLog(`[DEVICE] ${trimmed}`);
       }
     }
+    mcpBridge.scheduleConsoleWrite();
   });
 
   bleManager.onLog((message) => {
@@ -142,11 +156,13 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.registerTreeDataProvider('openblink-device-info', deviceInfoProvider),
     vscode.window.registerTreeDataProvider('openblink-metrics', metricsProvider),
     vscode.window.registerTreeDataProvider('openblink-board-reference', boardReferenceProvider),
+    vscode.window.registerTreeDataProvider('openblink-mcp-status', mcpStatusProvider),
     { dispose: () => devicesProvider.dispose() },
     { dispose: () => tasksProvider.dispose() },
     { dispose: () => deviceInfoProvider.dispose() },
     { dispose: () => metricsProvider.dispose() },
-    { dispose: () => boardReferenceProvider.dispose() }
+    { dispose: () => boardReferenceProvider.dispose() },
+    { dispose: () => mcpStatusProvider.dispose() }
   );
 
   // Load boards
@@ -160,6 +176,121 @@ export function activate(context: vscode.ExtensionContext) {
   if (currentBoard) {
     boardReferenceProvider.updateReference(boardManager.getLocalizedReferencePath(currentBoard));
   }
+
+  // ========================================================================
+  // MCP Bridge (file-based IPC for AI agent integration)
+  // ========================================================================
+
+  // Register MCP build trigger callback — invoked when the MCP server
+  // (or a Cascade Hook) writes a `trigger.json` file.
+  // NOTE: Must be registered BEFORE initialize() so that any existing
+  // trigger.json at startup is not consumed without being processed.
+  mcpBridge.onBuildTrigger(async (filePath: string, requestId: string) => {
+    ui.log(`[MCP] Build trigger received: ${filePath} (${requestId})`);
+    mcpStatusProvider.update({ lastTriggerTime: new Date(), lastTriggerRequestId: requestId });
+    try {
+      const sourceUri = vscode.Uri.file(filePath);
+      const buildResult = await buildAndBlink(context, sourceUri, { silent: true });
+
+      // Write build result for MCP server to consume
+      const history = ui.getMetricsHistory();
+      const lastCompile = history.compile.length > 0 ? history.compile[history.compile.length - 1] : undefined;
+      const lastTransfer = history.transfer.length > 0 ? history.transfer[history.transfer.length - 1] : undefined;
+      const lastSize = history.size.length > 0 ? history.size[history.size.length - 1] : undefined;
+
+      mcpBridge.writeBuildResult({
+        requestId,
+        success: buildResult.success,
+        compileTime: buildResult.success ? lastCompile : undefined,
+        transferTime: buildResult.success ? lastTransfer : undefined,
+        programSize: buildResult.success ? lastSize : undefined,
+        error: buildResult.error,
+      });
+      mcpStatusProvider.update({
+        lastResultTime: new Date(),
+        lastResultSuccess: buildResult.success,
+        lastResultError: buildResult.error,
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      mcpBridge.writeBuildResult({ requestId, success: false, error: msg });
+      mcpStatusProvider.update({ lastResultTime: new Date(), lastResultSuccess: false, lastResultError: msg });
+    }
+  });
+
+  mcpBridge.initialize(context);
+
+  // Set initial MCP enabled state immediately after initialize() reads the
+  // setting, before any debounced writes can fire.
+  mcpStatusProvider.update({ mcpEnabled: mcpBridge.isEnabled() });
+
+  // Set up MCP write callbacks to update the MCP status tree view
+  mcpBridge.setWriteCallbacks({
+    onStatusWritten: () => mcpStatusProvider.update({ lastStatusWriteTime: new Date() }),
+    onConsoleWritten: () => mcpStatusProvider.update({ lastConsoleWriteTime: new Date() }),
+  });
+
+  // Set initial board status for MCP
+  if (currentBoard) {
+    mcpBridge.updateBoardStatus({
+      name: currentBoard.name,
+      displayName: currentBoard.displayName,
+      referencePath: boardManager.getLocalizedReferencePath(currentBoard),
+    });
+  }
+
+  // Register MCP Server Definition Provider for VS Code Copilot auto-discovery.
+  // This allows Copilot Agent Mode to discover and use the OpenBlink MCP server
+  // without any manual configuration in mcp.json.
+  if (typeof vscode.lm?.registerMcpServerDefinitionProvider === 'function') {
+    const mcpServerModule = vscode.Uri.joinPath(context.extensionUri, 'out', 'mcp-server.js').fsPath;
+    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '';
+
+    context.subscriptions.push(
+      vscode.lm.registerMcpServerDefinitionProvider('openblink.mcpServer', {
+        provideMcpServerDefinitions: async () => {
+          if (!mcpBridge.isEnabled()) { return []; }
+          return [
+            new vscode.McpStdioServerDefinition(
+              'OpenBlink',
+              'node',
+              [mcpServerModule],
+              { OPENBLINK_WORKSPACE: workspaceRoot },
+              extensionVersion,
+            ),
+          ];
+        },
+        resolveMcpServerDefinition: async (server: vscode.McpServerDefinition) => server,
+      }),
+    );
+  }
+
+  // Register setupMcp command — generates MCP configuration for Windsurf/Cursor/Cline
+  context.subscriptions.push(
+    vscode.commands.registerCommand('openblink.setupMcp', async () => {
+      const mcpServerPath = vscode.Uri.joinPath(context.extensionUri, 'out', 'mcp-server.js').fsPath;
+      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '';
+
+      const configSnippet = JSON.stringify({
+        mcpServers: {
+          openblink: {
+            command: 'node',
+            args: [mcpServerPath],
+            env: { OPENBLINK_WORKSPACE: workspaceRoot },
+          },
+        },
+      }, null, 2);
+
+      const doc = await vscode.workspace.openTextDocument({
+        content: configSnippet,
+        language: 'json',
+      });
+      await vscode.window.showTextDocument(doc);
+      vscode.window.showInformationMessage(
+        l10n.t('Copy this MCP server configuration to your IDE\'s MCP config file.'),
+      );
+    }),
+  );
 
   // Initialize compiler
   initCompiler(context.extensionUri).then(() => {
@@ -210,12 +341,14 @@ export function activate(context: vscode.ExtensionContext) {
       if (e.affectsConfiguration('openblink.sourceFile')) {
         currentSourceFile = vscode.workspace.getConfiguration('openblink').get<string>('sourceFile') ?? 'app.rb';
         tasksProvider.update({ sourceFile: currentSourceFile });
+        mcpBridge.updateStatus({ sourceFile: currentSourceFile });
       }
       if (e.affectsConfiguration('openblink.slot')) {
         const raw = vscode.workspace.getConfiguration('openblink').get<number>('slot');
         currentSlot = (raw === 1 || raw === 2) ? raw : 2;
         tasksProvider.update({ slot: currentSlot });
         ui.updateStatusBar(bleManager.connectionState, bleManager.deviceName, undefined, currentSlot);
+        mcpBridge.updateStatus({ slot: currentSlot });
       }
       if (e.affectsConfiguration('openblink.board')) {
         const boards = boardManager.getBoards();
@@ -225,7 +358,19 @@ export function activate(context: vscode.ExtensionContext) {
           boardManager.setCurrentBoard(found);
           tasksProvider.update({ boardName: found.displayName });
           boardReferenceProvider.updateReference(boardManager.getLocalizedReferencePath(found));
+          mcpBridge.updateBoardStatus({
+            name: found.name,
+            displayName: found.displayName,
+            referencePath: boardManager.getLocalizedReferencePath(found),
+          });
         }
+      }
+      // Dynamic MCP enable/disable
+      if (e.affectsConfiguration('openblink.mcp.enabled')) {
+        const newEnabled = vscode.workspace.getConfiguration('openblink').get<boolean>('mcp.enabled', true);
+        mcpBridge.setEnabled(newEnabled);
+        mcpStatusProvider.update({ mcpEnabled: newEnabled });
+        ui.log(`[MCP] Integration ${newEnabled ? 'enabled' : 'disabled'}.`);
       }
     }),
   );
@@ -436,17 +581,17 @@ export function activate(context: vscode.ExtensionContext) {
  *                   skip does not show a user-facing warning (used for
  *                   auto-triggered builds from the save listener).
  */
-async function buildAndBlink(context: vscode.ExtensionContext, sourceUri: vscode.Uri, options?: { silent?: boolean }): Promise<void> {
+async function buildAndBlink(context: vscode.ExtensionContext, sourceUri: vscode.Uri, options?: { silent?: boolean }): Promise<{ success: boolean; error?: string }> {
   if (isBuilding) {
     ui.log('[SYSTEM] Build already in progress, skipping.');
     if (!options?.silent) {
       vscode.window.showWarningMessage(l10n.t('Build already in progress'));
     }
-    return;
+    return { success: false, error: 'Build already in progress' };
   }
   isBuilding = true;
   try {
-    await buildAndBlinkInner(context, sourceUri);
+    return await buildAndBlinkInner(context, sourceUri);
   } finally {
     isBuilding = false;
   }
@@ -462,12 +607,14 @@ async function buildAndBlink(context: vscode.ExtensionContext, sourceUri: vscode
  * @param context    Extension context (unused here but kept for API symmetry).
  * @param sourceUri  URI of the Ruby source file to compile.
  */
-async function buildAndBlinkInner(context: vscode.ExtensionContext, sourceUri: vscode.Uri): Promise<void> {
+async function buildAndBlinkInner(context: vscode.ExtensionContext, sourceUri: vscode.Uri): Promise<{ success: boolean; error?: string }> {
   try {
     await vscode.workspace.fs.stat(sourceUri);
   } catch {
-    vscode.window.showErrorMessage(l10n.t('Source file not found: {0}', sourceUri.fsPath));
-    return;
+    const errorMsg = l10n.t('Source file not found: {0}', sourceUri.fsPath);
+    vscode.window.showErrorMessage(errorMsg);
+    mcpBridge.updateBuildResult(false, errorMsg);
+    return { success: false, error: errorMsg };
   }
 
   // Read source
@@ -486,7 +633,8 @@ async function buildAndBlinkInner(context: vscode.ExtensionContext, sourceUri: v
       ui.setDiagnostics(sourceUri, diagnostics);
     }
     vscode.window.showErrorMessage(l10n.t('Compilation failed'));
-    return;
+    mcpBridge.updateBuildResult(false, result.error ?? 'Compilation failed');
+    return { success: false, error: result.error ?? 'Compilation failed' };
   }
 
   ui.log(`[COMPILE] success: ${result.compileTime.toFixed(1)}ms, size: ${result.size} bytes`);
@@ -500,7 +648,14 @@ async function buildAndBlinkInner(context: vscode.ExtensionContext, sourceUri: v
     ui.recordMetrics(metrics);
     metricsProvider.updateMetrics(metrics);
     ui.updateStatusBar(bleManager.connectionState, bleManager.deviceName, metrics, currentSlot);
-    return;
+    const history = ui.getMetricsHistory();
+    mcpBridge.updateMetricsStatus(metrics, {
+      compile: ui.calculateStats(history.compile),
+      transfer: ui.calculateStats(history.transfer),
+      size: ui.calculateStats(history.size),
+    });
+    mcpBridge.updateBuildResult(false, 'Device is not connected');
+    return { success: false, error: 'Compiled successfully but device is not connected' };
   }
 
   const transferStart = performance.now();
@@ -516,13 +671,23 @@ async function buildAndBlinkInner(context: vscode.ExtensionContext, sourceUri: v
     ui.recordMetrics(metrics);
     metricsProvider.updateMetrics(metrics);
     ui.updateStatusBar('connected', bleManager.deviceName, metrics, currentSlot);
+    const history = ui.getMetricsHistory();
+    mcpBridge.updateMetricsStatus(metrics, {
+      compile: ui.calculateStats(history.compile),
+      transfer: ui.calculateStats(history.transfer),
+      size: ui.calculateStats(history.size),
+    });
+    mcpBridge.updateBuildResult(true);
 
     ui.log(`[COMPILE] ${l10n.t('Compilation successful: {0}ms, size: {1} bytes', result.compileTime.toFixed(1), String(result.size))}`);
     ui.log(`[TRANSFER] ${l10n.t('Transfer complete: {0}ms', transferTime.toFixed(1))}`);
+    return { success: true };
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     ui.log(`[TRANSFER] Error: ${msg}`);
     vscode.window.showErrorMessage(msg);
+    mcpBridge.updateBuildResult(false, msg);
+    return { success: false, error: msg };
   }
 }
 

--- a/src/mcp-bridge.ts
+++ b/src/mcp-bridge.ts
@@ -1,0 +1,431 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: Copyright (c) 2026 OpenBlink All Rights Reserved.
+ */
+
+/**
+ * @brief File-based IPC bridge between the VS Code extension and the MCP server.
+ *
+ * The extension (running inside the extension host process) and the MCP server
+ * (running as a separate stdio-based Node.js process) communicate through JSON
+ * files stored in the `.openblink/` directory at the workspace root:
+ *
+ *   - `status.json`  — Written by the extension (debounced 1 s) on connection
+ *                       state changes and build completions.
+ *   - `openblink-console.log` — Written by the extension (debounced 2 s) with
+ *                       the most recent device console output (up to 100 lines).
+ *   - `trigger.json` — Written by the MCP server to request a Build & Blink.
+ *   - `result.json`  — Written by the extension after a triggered build
+ *                       completes so the MCP server can return the outcome.
+ *
+ * All write operations are guarded by the `openblink.mcp.enabled` setting.
+ * When the setting is `false`, no files are written and the FileSystemWatcher
+ * for `trigger.json` is disposed.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { ConnectionState, MetricsData, MetricsHistory, MetricsStats } from './types';
+import { getConsoleLog, log } from './ui-manager';
+
+// ============================================================================
+// Directory & File Paths
+// ============================================================================
+
+/** @brief Name of the IPC directory created at the workspace root. */
+const IPC_DIR = '.openblink';
+
+/** @brief Resolve the absolute path to the IPC directory for the first workspace folder. */
+function ipcDir(): string | undefined {
+  const ws = vscode.workspace.workspaceFolders?.[0];
+  return ws ? path.join(ws.uri.fsPath, IPC_DIR) : undefined;
+}
+
+/** @brief Ensure the `.openblink/` directory exists. */
+function ensureDir(): string | undefined {
+  const dir = ipcDir();
+  if (dir && !fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+// ============================================================================
+// Enabled State
+// ============================================================================
+
+/** @brief Current enabled state, mirroring `openblink.mcp.enabled`. */
+let enabled = true;
+
+/** @brief FileSystemWatcher for `trigger.json`. */
+let triggerWatcher: vscode.FileSystemWatcher | undefined;
+
+/** @brief Callback invoked when a build trigger is detected. */
+let onTriggerCallback: ((filePath: string, requestId: string) => Promise<void>) | undefined;
+
+// ============================================================================
+// Write Callbacks (for UI notification)
+// ============================================================================
+
+/** @brief Callback type for IPC file write notifications. */
+type WriteCallback = () => void;
+
+/** @brief Callback invoked after a successful `status.json` write. */
+let onStatusWrittenCallback: WriteCallback | undefined;
+
+/** @brief Callback invoked after a successful `openblink-console.log` write. */
+let onConsoleWrittenCallback: WriteCallback | undefined;
+
+/**
+ * @brief Register callbacks invoked after IPC file writes.
+ *
+ * These callbacks allow the extension host (e.g. {@link McpStatusTreeProvider})
+ * to update the UI whenever the bridge writes an IPC file.
+ *
+ * @param opts  Object with optional `onStatusWritten` and `onConsoleWritten` callbacks.
+ */
+export function setWriteCallbacks(opts: {
+  onStatusWritten?: WriteCallback;
+  onConsoleWritten?: WriteCallback;
+}): void {
+  onStatusWrittenCallback = opts.onStatusWritten;
+  onConsoleWrittenCallback = opts.onConsoleWritten;
+}
+
+/**
+ * @brief Check whether MCP IPC is currently enabled.
+ * @returns `true` if the `openblink.mcp.enabled` setting is `true`.
+ */
+export function isEnabled(): boolean {
+  return enabled;
+}
+
+/**
+ * @brief Update the enabled state.
+ *
+ * When transitioning from enabled → disabled, the trigger watcher is disposed.
+ * Existing IPC files are left on disk (they become stale but harmless).
+ * When transitioning from disabled → enabled, the IPC directory and trigger
+ * watcher are re-created.
+ *
+ * @param value  New enabled state.
+ */
+export function setEnabled(value: boolean): void {
+  const wasEnabled = enabled;
+  enabled = value;
+
+  if (wasEnabled && !enabled) {
+    // Disable: dispose watcher
+    triggerWatcher?.dispose();
+    triggerWatcher = undefined;
+  } else if (!wasEnabled && enabled) {
+    // Enable: re-create watcher
+    startTriggerWatcher();
+  }
+}
+
+// ============================================================================
+// Status File (debounced 1 s)
+// ============================================================================
+
+/**
+ * @brief Shape of the `status.json` file written to `.openblink/`.
+ */
+export interface McpStatus {
+  connection: {
+    state: ConnectionState;
+    deviceName: string | null;
+    deviceId: string | null;
+    mtu: number;
+  };
+  metrics: {
+    latest: MetricsData;
+    stats: {
+      compile: MetricsStats;
+      transfer: MetricsStats;
+      size: MetricsStats;
+    };
+  };
+  board: {
+    name: string;
+    displayName: string;
+    referencePath: string;
+  } | null;
+  sourceFile: string;
+  slot: number;
+  lastBuild: {
+    success: boolean;
+    timestamp: string;
+    error?: string;
+  } | null;
+}
+
+/** @brief Debounce timer handle for status file writes. */
+let statusTimer: ReturnType<typeof setTimeout> | undefined;
+
+/** @brief Cached status object, updated incrementally. */
+let currentStatus: McpStatus = {
+  connection: { state: 'disconnected', deviceName: null, deviceId: null, mtu: 20 },
+  metrics: {
+    latest: {},
+    stats: {
+      compile: { min: null, avg: null, max: null },
+      transfer: { min: null, avg: null, max: null },
+      size: { min: null, avg: null, max: null },
+    },
+  },
+  board: null,
+  sourceFile: 'app.rb',
+  slot: 2,
+  lastBuild: null,
+};
+
+/**
+ * @brief Merge partial updates into the current status and schedule a debounced write.
+ * @param patch  Partial status fields to merge.
+ */
+export function updateStatus(patch: Partial<McpStatus>): void {
+  if (!enabled) { return; }
+  // NOTE: shallow merge — only use with top-level primitive fields.
+  // For nested objects (connection, metrics, board), use the dedicated update functions.
+  Object.assign(currentStatus, patch);
+  scheduleStatusWrite();
+}
+
+/**
+ * @brief Update the connection-related fields of the status.
+ */
+export function updateConnectionStatus(
+  state: ConnectionState,
+  deviceName: string | null,
+  deviceId: string | null,
+  mtu: number,
+): void {
+  if (!enabled) { return; }
+  currentStatus.connection = { state, deviceName, deviceId, mtu };
+  scheduleStatusWrite();
+}
+
+/**
+ * @brief Update the metrics fields of the status.
+ */
+export function updateMetricsStatus(latest: MetricsData, stats: { compile: MetricsStats; transfer: MetricsStats; size: MetricsStats }): void {
+  if (!enabled) { return; }
+  currentStatus.metrics = { latest, stats };
+  scheduleStatusWrite();
+}
+
+/**
+ * @brief Update the board field of the status.
+ */
+export function updateBoardStatus(board: { name: string; displayName: string; referencePath: string } | null): void {
+  if (!enabled) { return; }
+  currentStatus.board = board;
+  scheduleStatusWrite();
+}
+
+/**
+ * @brief Update the last build result field of the status.
+ */
+export function updateBuildResult(success: boolean, error?: string): void {
+  if (!enabled) { return; }
+  currentStatus.lastBuild = { success, timestamp: new Date().toISOString(), error };
+  scheduleStatusWrite();
+}
+
+/** @brief Schedule a debounced write of `status.json` (1 second delay). */
+function scheduleStatusWrite(): void {
+  if (statusTimer) { clearTimeout(statusTimer); }
+  statusTimer = setTimeout(() => flushStatus(), 1000);
+}
+
+/** @brief Write the current status to `status.json`. */
+function flushStatus(): void {
+  if (!enabled) { return; }
+  const dir = ensureDir();
+  if (!dir) { return; }
+  let written = false;
+  try {
+    fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify(currentStatus, null, 2), 'utf-8');
+    written = true;
+  } catch {
+    // Silently ignore write errors (e.g. permission issues)
+  }
+  if (written) { onStatusWrittenCallback?.(); }
+}
+
+// ============================================================================
+// Console Log File (debounced 2 s)
+// ============================================================================
+
+/** @brief Debounce timer handle for console log file writes. */
+let consoleTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * @brief Schedule a debounced write of the console ring buffer to `openblink-console.log`.
+ *
+ * Called from the extension whenever new console output is received.
+ * The actual file write is delayed by 2 seconds and batched.
+ */
+export function scheduleConsoleWrite(): void {
+  if (!enabled) { return; }
+  if (consoleTimer) { clearTimeout(consoleTimer); }
+  consoleTimer = setTimeout(() => flushConsole(), 2000);
+}
+
+/** @brief Write the current console buffer to `openblink-console.log`. */
+function flushConsole(): void {
+  if (!enabled) { return; }
+  const dir = ensureDir();
+  if (!dir) { return; }
+  let written = false;
+  try {
+    const lines = getConsoleLog();
+    fs.writeFileSync(path.join(dir, 'openblink-console.log'), lines.join('\n') + '\n', 'utf-8');
+    written = true;
+  } catch {
+    // Silently ignore write errors
+  }
+  if (written) { onConsoleWrittenCallback?.(); }
+}
+
+// ============================================================================
+// Build Result File (immediate write)
+// ============================================================================
+
+/**
+ * @brief Shape of the `result.json` file written after a triggered build.
+ */
+export interface McpBuildResult {
+  requestId: string;
+  success: boolean;
+  compileTime?: number;
+  transferTime?: number;
+  programSize?: number;
+  error?: string;
+}
+
+/**
+ * @brief Write a build result file for the MCP server to consume.
+ * @param result  Build outcome.
+ */
+export function writeBuildResult(result: McpBuildResult): void {
+  if (!enabled) { return; }
+  const dir = ensureDir();
+  if (!dir) { return; }
+  try {
+    fs.writeFileSync(path.join(dir, 'result.json'), JSON.stringify(result, null, 2), 'utf-8');
+  } catch {
+    // Silently ignore write errors
+  }
+  log(`[MCP] Build result written: ${result.success ? 'Success' : 'Failed'}${result.error ? ` (${result.error})` : ''}`);
+}
+
+// ============================================================================
+// Trigger Watcher
+// ============================================================================
+
+/**
+ * @brief Shape of the `trigger.json` file written by the MCP server.
+ */
+export interface McpBuildTrigger {
+  file?: string;
+  requestId: string;
+}
+
+/**
+ * @brief Register the callback that is invoked when `trigger.json` is detected.
+ * @param callback  Async function receiving the resolved file path and request ID.
+ */
+export function onBuildTrigger(callback: (filePath: string, requestId: string) => Promise<void>): void {
+  onTriggerCallback = callback;
+}
+
+/**
+ * @brief Start watching for `trigger.json` in the `.openblink/` directory.
+ *
+ * Creates a {@link vscode.FileSystemWatcher} that fires when the MCP server
+ * writes or updates the trigger file.  The watcher reads the trigger,
+ * deletes the file, and invokes the registered callback.
+ */
+function startTriggerWatcher(): void {
+  if (triggerWatcher) { return; }
+  const dir = ipcDir();
+  if (!dir) { return; }
+
+  ensureDir();
+  const pattern = new vscode.RelativePattern(dir, 'trigger.json');
+  triggerWatcher = vscode.workspace.createFileSystemWatcher(pattern, false, false, true);
+
+  const handleTrigger = async () => {
+    const triggerPath = path.join(dir, 'trigger.json');
+    try {
+      if (!fs.existsSync(triggerPath)) { return; }
+      const raw = fs.readFileSync(triggerPath, 'utf-8');
+      fs.unlinkSync(triggerPath);
+      const trigger: McpBuildTrigger = JSON.parse(raw);
+      if (!trigger.requestId || typeof trigger.requestId !== 'string') { return; }
+      if (onTriggerCallback) {
+        const ws = vscode.workspace.workspaceFolders?.[0];
+        const sourceFile = trigger.file
+          ?? vscode.workspace.getConfiguration('openblink').get<string>('sourceFile')
+          ?? 'app.rb';
+        const filePath = ws ? path.join(ws.uri.fsPath, sourceFile) : sourceFile;
+        // Guard against path traversal: resolved path must stay within the workspace
+        if (ws && !path.resolve(filePath).startsWith(ws.uri.fsPath + path.sep) && path.resolve(filePath) !== ws.uri.fsPath) { return; }
+        await onTriggerCallback(filePath, trigger.requestId);
+      }
+    } catch {
+      // Ignore malformed trigger files
+    }
+  };
+
+  triggerWatcher.onDidCreate(handleTrigger);
+  triggerWatcher.onDidChange(handleTrigger);
+
+  // Process any trigger.json that was written before the watcher started
+  const existingTrigger = path.join(dir, 'trigger.json');
+  if (fs.existsSync(existingTrigger)) {
+    void handleTrigger();
+  }
+}
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+/**
+ * @brief Initialize the MCP bridge.
+ *
+ * Reads the `openblink.mcp.enabled` setting, creates the IPC directory if
+ * needed, and starts the trigger watcher if MCP is enabled.
+ *
+ * @param context  The extension context for registering disposables.
+ */
+export function initialize(context: vscode.ExtensionContext): void {
+  enabled = vscode.workspace.getConfiguration('openblink').get<boolean>('mcp.enabled', true);
+
+  // Read initial config values
+  const config = vscode.workspace.getConfiguration('openblink');
+  currentStatus.sourceFile = config.get<string>('sourceFile') ?? 'app.rb';
+  currentStatus.slot = config.get<number>('slot') ?? 2;
+
+  if (enabled) {
+    startTriggerWatcher();
+    scheduleStatusWrite();
+    log('[MCP] Bridge initialized (IPC enabled).');
+  } else {
+    log('[MCP] Bridge initialized (IPC disabled).');
+  }
+
+  // Dispose watcher on deactivation
+  context.subscriptions.push({
+    dispose: () => {
+      triggerWatcher?.dispose();
+      triggerWatcher = undefined;
+      if (statusTimer) { clearTimeout(statusTimer); }
+      if (consoleTimer) { clearTimeout(consoleTimer); }
+    },
+  });
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: Copyright (c) 2026 OpenBlink All Rights Reserved.
+ */
+
+/**
+ * @brief OpenBlink MCP Server — stdio-based Model Context Protocol server.
+ *
+ * This standalone Node.js script is bundled with the OpenBlink VS Code
+ * extension and launched as a child process by the IDE's MCP client
+ * (Windsurf Cascade, VS Code Copilot, Cursor, Cline, etc.).
+ *
+ * Communication with the extension happens through JSON files in the
+ * `.openblink/` directory at the workspace root (file-based IPC):
+ *
+ *   - Reads  `status.json`  for device info and metrics.
+ *   - Reads  `openblink-console.log` for device console output.
+ *   - Writes `trigger.json` to request a Build & Blink.
+ *   - Reads  `result.json`  for the build outcome.
+ *
+ * Registered MCP tools:
+ *   1. `build_and_blink` — Compile a .rb file and transfer via BLE.
+ *   2. `get_device_info`  — Return the current device connection state.
+ *   3. `get_console_output` — Return recent device console output.
+ *   4. `get_metrics`     — Return build/transfer metrics and statistics.
+ *   5. `get_board_reference` — Return the board API reference (Markdown).
+ *
+ * @see https://modelcontextprotocol.io/
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import * as fs from 'fs';
+import * as path from 'path';
+
+declare const EXTENSION_VERSION: string;
+
+// ============================================================================
+// IPC Directory
+// ============================================================================
+
+/**
+ * @brief Resolve the `.openblink/` IPC directory path.
+ *
+ * The workspace root is passed as the `OPENBLINK_WORKSPACE` environment
+ * variable by the extension when it launches the MCP server.
+ */
+function getIpcDir(): string {
+  const workspace = process.env.OPENBLINK_WORKSPACE;
+  if (!workspace) {
+    throw new Error('OPENBLINK_WORKSPACE environment variable is not set');
+  }
+  return path.join(workspace, '.openblink');
+}
+
+/** @brief Safely read and parse a JSON file.  Returns `null` on any error. */
+function readJsonFile<T>(filePath: string): T | null {
+  try {
+    if (!fs.existsSync(filePath)) { return null; }
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/** @brief Safely read a text file.  Returns `null` on any error. */
+function readTextFile(filePath: string): string | null {
+  try {
+    if (!fs.existsSync(filePath)) { return null; }
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// MCP Server Setup
+// ============================================================================
+
+const server = new McpServer({
+  name: 'OpenBlink',
+  version: EXTENSION_VERSION,
+});
+
+// ----------------------------------------------------------------------------
+// Tool: build_and_blink
+// ----------------------------------------------------------------------------
+
+server.tool(
+  'build_and_blink',
+  'Compile a Ruby (.rb) file with mruby and transfer the bytecode to a BLE-connected OpenBlink device. ' +
+  'Call this after editing a .rb file to deploy changes to the hardware. ' +
+  'Returns compile time, transfer time, program size, and success/error status. ' +
+  'Requires an OpenBlink device to be connected via BLE for transfer (compilation works without a device).',
+  {
+    file: z.string().optional().describe(
+      'Path to the .rb source file relative to the workspace root. ' +
+      'If omitted, the configured openblink.sourceFile setting is used (default: app.rb).'
+    ),
+  },
+  async ({ file }) => {
+    const dir = getIpcDir();
+    const requestId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+    // Write trigger file
+    const trigger = { file, requestId };
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'trigger.json'), JSON.stringify(trigger, null, 2), 'utf-8');
+
+    // Poll for result (max 30 seconds)
+    const resultPath = path.join(dir, 'result.json');
+    const timeout = 30_000;
+    const poll = 200;
+    const start = Date.now();
+
+    while (Date.now() - start < timeout) {
+      await new Promise(resolve => setTimeout(resolve, poll));
+      const result = readJsonFile<{
+        requestId: string;
+        success: boolean;
+        compileTime?: number;
+        transferTime?: number;
+        programSize?: number;
+        error?: string;
+      }>(resultPath);
+
+      if (result && result.requestId === requestId) {
+        // Clean up result file
+        try { fs.unlinkSync(resultPath); } catch { /* ignore */ }
+
+        if (result.success) {
+          const parts = [
+            `Build & Blink completed successfully.`,
+            result.compileTime !== undefined ? `Compile time: ${result.compileTime.toFixed(1)} ms` : null,
+            result.transferTime !== undefined ? `Transfer time: ${result.transferTime.toFixed(1)} ms` : null,
+            result.programSize !== undefined ? `Program size: ${result.programSize} bytes` : null,
+          ].filter(Boolean);
+          return { content: [{ type: 'text' as const, text: parts.join('\n') }] };
+        } else {
+          return {
+            content: [{ type: 'text' as const, text: `Build & Blink failed: ${result.error ?? 'Unknown error'}` }],
+            isError: true,
+          };
+        }
+      }
+    }
+
+    return {
+      content: [{ type: 'text' as const, text: 'Build & Blink timed out after 30 seconds. Is the OpenBlink extension running?' }],
+      isError: true,
+    };
+  },
+);
+
+// ----------------------------------------------------------------------------
+// Tool: get_device_info
+// ----------------------------------------------------------------------------
+
+server.tool(
+  'get_device_info',
+  'Get the current BLE connection state and device information for the connected OpenBlink device. ' +
+  'Returns connection state (disconnected/connecting/connected/reconnecting), device name, device ID, and negotiated MTU.',
+  {},
+  async () => {
+    const dir = getIpcDir();
+    const status = readJsonFile<{ connection: { state: string; deviceName: string | null; deviceId: string | null; mtu: number } }>(
+      path.join(dir, 'status.json'),
+    );
+
+    if (!status) {
+      return { content: [{ type: 'text' as const, text: 'No status available. Is the OpenBlink extension running with MCP enabled?' }] };
+    }
+
+    const c = status.connection;
+    const lines = [
+      `Connection state: ${c.state}`,
+      `Device name: ${c.deviceName ?? '(none)'}`,
+      `Device ID: ${c.deviceId ?? '(none)'}`,
+      `MTU: ${c.mtu}`,
+    ];
+    return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+  },
+);
+
+// ----------------------------------------------------------------------------
+// Tool: get_console_output
+// ----------------------------------------------------------------------------
+
+server.tool(
+  'get_console_output',
+  'Get recent console output from the connected OpenBlink device. ' +
+  'Returns up to 100 lines of the most recent [DEVICE] log messages. ' +
+  'Use this to see runtime output, debug prints, and error messages from the mruby/c program running on the device.',
+  {
+    lines: z.number().optional().describe(
+      'Maximum number of lines to return (default: all available, up to 100).'
+    ),
+  },
+  async ({ lines: maxLines }) => {
+    const dir = getIpcDir();
+    const raw = readTextFile(path.join(dir, 'openblink-console.log'));
+
+    if (!raw || raw.trim().length === 0) {
+      return { content: [{ type: 'text' as const, text: 'No console output available.' }] };
+    }
+
+    let logLines = raw.split('\n').filter(l => l.length > 0);
+    if (maxLines !== undefined && maxLines > 0) {
+      logLines = logLines.slice(-maxLines);
+    }
+
+    return { content: [{ type: 'text' as const, text: logLines.join('\n') }] };
+  },
+);
+
+// ----------------------------------------------------------------------------
+// Tool: get_metrics
+// ----------------------------------------------------------------------------
+
+server.tool(
+  'get_metrics',
+  'Get build and transfer metrics for the OpenBlink extension. ' +
+  'Returns the latest compile time, transfer time, program size, and min/avg/max statistics across recent builds.',
+  {},
+  async () => {
+    const dir = getIpcDir();
+    const status = readJsonFile<{
+      metrics: {
+        latest: { compileTime?: number; transferTime?: number; programSize?: number };
+        stats: {
+          compile: { min: number | null; avg: number | null; max: number | null };
+          transfer: { min: number | null; avg: number | null; max: number | null };
+          size: { min: number | null; avg: number | null; max: number | null };
+        };
+      };
+    }>(path.join(dir, 'status.json'));
+
+    if (!status) {
+      return { content: [{ type: 'text' as const, text: 'No metrics available. Is the OpenBlink extension running with MCP enabled?' }] };
+    }
+
+    const m = status.metrics;
+    const fmt = (v: number | undefined | null, unit: string) =>
+      v !== undefined && v !== null ? `${v.toFixed?.(1) ?? v} ${unit}` : '--';
+    const fmtStat = (s: { min: number | null; avg: number | null; max: number | null }, unit: string) =>
+      `min=${fmt(s.min, unit)} avg=${fmt(s.avg, unit)} max=${fmt(s.max, unit)}`;
+
+    const lines = [
+      `=== Latest Build ===`,
+      `Compile time: ${fmt(m.latest.compileTime, 'ms')}`,
+      `Transfer time: ${fmt(m.latest.transferTime, 'ms')}`,
+      `Program size: ${fmt(m.latest.programSize, 'bytes')}`,
+      ``,
+      `=== Statistics ===`,
+      `Compile: ${fmtStat(m.stats.compile, 'ms')}`,
+      `Transfer: ${fmtStat(m.stats.transfer, 'ms')}`,
+      `Size: ${fmtStat(m.stats.size, 'bytes')}`,
+    ];
+    return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+  },
+);
+
+// ----------------------------------------------------------------------------
+// Tool: get_board_reference
+// ----------------------------------------------------------------------------
+
+server.tool(
+  'get_board_reference',
+  'Get the API reference documentation (Markdown) for the currently selected OpenBlink board. ' +
+  'Returns the board name and the full reference Markdown content describing available APIs ' +
+  '(LED, GPIO, Sleep, etc.) that can be used in mruby programs.',
+  {},
+  async () => {
+    const dir = getIpcDir();
+    const status = readJsonFile<{
+      board: { name: string; displayName: string; referencePath: string } | null;
+    }>(path.join(dir, 'status.json'));
+
+    if (!status?.board) {
+      return { content: [{ type: 'text' as const, text: 'No board selected. Use the OpenBlink sidebar to select a board.' }] };
+    }
+
+    const refContent = readTextFile(status.board.referencePath);
+    if (!refContent) {
+      return { content: [{ type: 'text' as const, text: `Board "${status.board.displayName}" selected, but reference file not found at: ${status.board.referencePath}` }] };
+    }
+
+    return { content: [{ type: 'text' as const, text: `# ${status.board.displayName}\n\n${refContent}` }] };
+  },
+);
+
+// ============================================================================
+// Start Server
+// ============================================================================
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  process.stderr.write(`OpenBlink MCP server error: ${error}\n`);
+  process.exit(1);
+});

--- a/src/ui-manager.ts
+++ b/src/ui-manager.ts
@@ -45,6 +45,41 @@ export function log(message: string): void {
 }
 
 // ============================================================================
+// Console Output Buffer (for MCP integration)
+// ============================================================================
+
+/** @brief Maximum number of lines retained in the console output ring buffer. */
+const MAX_CONSOLE_BUFFER = 100;
+
+/** @brief Ring buffer for [DEVICE] console output lines, exposed to MCP server via file IPC. */
+const consoleBuffer: string[] = [];
+
+/**
+ * @brief Append a line to the in-memory console ring buffer.
+ *
+ * When the buffer exceeds {@link MAX_CONSOLE_BUFFER} lines, the oldest
+ * entries are discarded.  The MCP bridge reads this buffer via
+ * {@link getConsoleLog} to write it to the IPC file.
+ *
+ * @param line  A single console output line (without trailing newline).
+ */
+export function appendConsoleLog(line: string): void {
+  consoleBuffer.push(line);
+  if (consoleBuffer.length > MAX_CONSOLE_BUFFER) {
+    consoleBuffer.splice(0, consoleBuffer.length - MAX_CONSOLE_BUFFER);
+  }
+}
+
+/**
+ * @brief Return a snapshot of the console ring buffer.
+ * @returns An array of the most recent console output lines (up to
+ *          {@link MAX_CONSOLE_BUFFER}).
+ */
+export function getConsoleLog(): string[] {
+  return [...consoleBuffer];
+}
+
+// ============================================================================
 // Diagnostics
 // ============================================================================
 
@@ -782,6 +817,142 @@ export class BoardReferenceTreeProvider implements vscode.TreeDataProvider<vscod
     }
 
     return sections;
+  }
+
+  /** @brief Dispose the internal event emitter. */
+  dispose(): void { this._onDidChangeTreeData.dispose(); }
+}
+
+// ============================================================================
+// MCP Status TreeView
+// ============================================================================
+
+/**
+ * @brief TreeDataProvider that displays MCP integration status in the sidebar.
+ *
+ * Shows whether MCP is enabled, IPC file activity timestamps, the last
+ * build request received from the MCP server, and the last build result.
+ */
+export class McpStatusTreeProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<vscode.TreeItem | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private mcpEnabled = true;
+  private lastTriggerTime: Date | null = null;
+  private lastTriggerRequestId: string | null = null;
+  private lastResultTime: Date | null = null;
+  private lastResultSuccess: boolean | null = null;
+  private lastResultError: string | undefined;
+  private lastStatusWriteTime: Date | null = null;
+  private lastConsoleWriteTime: Date | null = null;
+
+  /** @brief Trigger a tree view refresh. */
+  refresh(): void { this._onDidChangeTreeData.fire(); }
+
+  /**
+   * @brief Update displayed MCP status and refresh the tree view.
+   * @param opts  Partial set of properties to update.
+   */
+  update(opts: {
+    mcpEnabled?: boolean;
+    lastTriggerTime?: Date;
+    lastTriggerRequestId?: string;
+    lastResultTime?: Date;
+    lastResultSuccess?: boolean;
+    lastResultError?: string;
+    lastStatusWriteTime?: Date;
+    lastConsoleWriteTime?: Date;
+  }): void {
+    if (opts.mcpEnabled !== undefined) { this.mcpEnabled = opts.mcpEnabled; }
+    if (opts.lastTriggerTime !== undefined) { this.lastTriggerTime = opts.lastTriggerTime; }
+    if (opts.lastTriggerRequestId !== undefined) { this.lastTriggerRequestId = opts.lastTriggerRequestId; }
+    if (opts.lastResultTime !== undefined) { this.lastResultTime = opts.lastResultTime; }
+    if (opts.lastResultSuccess !== undefined) { this.lastResultSuccess = opts.lastResultSuccess; }
+    if (opts.lastResultError !== undefined) { this.lastResultError = opts.lastResultError; }
+    if (opts.lastStatusWriteTime !== undefined) { this.lastStatusWriteTime = opts.lastStatusWriteTime; }
+    if (opts.lastConsoleWriteTime !== undefined) { this.lastConsoleWriteTime = opts.lastConsoleWriteTime; }
+    this.refresh();
+  }
+
+  /** @brief Return the tree item itself (no transformation needed). */
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem { return element; }
+
+  /**
+   * @brief Build the list of MCP status items for the view.
+   * @returns Array of tree items showing MCP integration state.
+   */
+  getChildren(): vscode.TreeItem[] {
+    const items: vscode.TreeItem[] = [];
+
+    // MCP enabled/disabled
+    const enabledItem = new vscode.TreeItem(
+      `MCP: ${this.mcpEnabled ? l10n.t('Enabled') : l10n.t('Disabled')}`
+    );
+    enabledItem.iconPath = this.mcpEnabled
+      ? new vscode.ThemeIcon('pass-filled', new vscode.ThemeColor('testing.iconPassed'))
+      : new vscode.ThemeIcon('circle-slash');
+    enabledItem.command = { command: 'workbench.action.openSettings', title: '', arguments: ['openblink.mcp.enabled'] };
+    items.push(enabledItem);
+
+    if (!this.mcpEnabled) {
+      return items;
+    }
+
+    // Status file write time
+    const statusItem = new vscode.TreeItem(
+      `${l10n.t('Status File')}: ${this.fmtTime(this.lastStatusWriteTime)}`
+    );
+    statusItem.iconPath = new vscode.ThemeIcon(this.lastStatusWriteTime ? 'file-symlink-file' : 'file');
+    items.push(statusItem);
+
+    // Console log write time
+    const consoleItem = new vscode.TreeItem(
+      `${l10n.t('Console Log')}: ${this.fmtTime(this.lastConsoleWriteTime)}`
+    );
+    consoleItem.iconPath = new vscode.ThemeIcon(this.lastConsoleWriteTime ? 'output' : 'file');
+    items.push(consoleItem);
+
+    // Last build request (trigger from MCP server)
+    const triggerItem = new vscode.TreeItem(
+      `${l10n.t('Last Request')}: ${this.fmtTime(this.lastTriggerTime)}`
+    );
+    triggerItem.iconPath = new vscode.ThemeIcon('arrow-down');
+    if (this.lastTriggerRequestId) {
+      triggerItem.description = this.lastTriggerRequestId;
+    }
+    items.push(triggerItem);
+
+    // Last build result
+    const resultLabel = this.lastResultSuccess !== null
+      ? `${l10n.t('Last Result')}: ${this.lastResultSuccess ? l10n.t('Success') : l10n.t('Failed')}`
+      : `${l10n.t('Last Result')}: --`;
+    const resultItem = new vscode.TreeItem(resultLabel);
+    if (this.lastResultSuccess === true) {
+      resultItem.iconPath = new vscode.ThemeIcon('pass-filled', new vscode.ThemeColor('testing.iconPassed'));
+    } else if (this.lastResultSuccess === false) {
+      resultItem.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('testing.iconFailed'));
+    } else {
+      resultItem.iconPath = new vscode.ThemeIcon('circle-slash');
+    }
+    if (this.lastResultTime) {
+      resultItem.description = this.fmtTime(this.lastResultTime);
+    }
+    if (this.lastResultSuccess === false && this.lastResultError) {
+      resultItem.tooltip = this.lastResultError;
+    }
+    items.push(resultItem);
+
+    return items;
+  }
+
+  /**
+   * @brief Format a Date as a locale-appropriate time string.
+   * @param date  Date to format, or null.
+   * @returns Formatted time string or '--' if null.
+   */
+  private fmtTime(date: Date | null): string {
+    if (!date) { return '--'; }
+    return date.toLocaleTimeString();
   }
 
   /** @brief Dispose the internal event emitter. */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,19 +2,27 @@
 'use strict';
 
 const path = require('path');
+const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const packageJson = require('./package.json');
 
 /**
  * @brief Webpack configuration for the OpenBlink VS Code extension.
  *
- * Bundles the TypeScript source into a single CommonJS module targeting
- * Node.js. Externals (`vscode`, `@abandonware/noble`) are excluded from
- * the bundle. Static assets (WASM compiler, icons, board resources) are
- * copied to the output directory via CopyWebpackPlugin.
+ * Produces two bundles:
+ *   1. `extension.js` — Main extension entry point (CommonJS, externals:
+ *      `vscode` and `@abandonware/noble`).
+ *   2. `mcp-server.js` — Standalone MCP server (CommonJS, no externals).
+ *      Launched as a child process by the IDE's MCP client via stdio.
  *
- * @type {import('webpack').Configuration}
+ * Static assets (WASM compiler, icons, board resources) are copied to
+ * the output directory via CopyWebpackPlugin (only in the extension config).
+ *
+ * @type {import('webpack').Configuration[]}
  */
-const config = {
+
+/** @brief Extension bundle configuration. */
+const extensionConfig = {
   target: 'node',
   mode: 'none',
 
@@ -56,4 +64,45 @@ const config = {
   }
 };
 
-module.exports = config;
+/**
+ * @brief MCP server bundle configuration.
+ *
+ * Produces a standalone Node.js script that communicates via stdio using
+ * the Model Context Protocol.  No VS Code or Noble externals — all
+ * dependencies are bundled into a single file.
+ */
+const mcpServerConfig = {
+  target: 'node',
+  mode: 'none',
+
+  entry: './src/mcp-server.ts',
+  output: {
+    path: path.resolve(__dirname, 'out'),
+    filename: 'mcp-server.js',
+    libraryTarget: 'commonjs2'
+  },
+  externals: {},
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: [{ loader: 'ts-loader' }]
+      }
+    ]
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      EXTENSION_VERSION: JSON.stringify(packageJson.version),
+    }),
+  ],
+  devtool: 'nosources-source-map',
+  infrastructureLogging: {
+    level: 'log'
+  }
+};
+
+module.exports = [extensionConfig, mcpServerConfig];


### PR DESCRIPTION
## Summary

Add a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that enables AI agents (Windsurf Cascade, VS Code Copilot, Cursor, Cline) to interact with OpenBlink devices programmatically.

This PR introduces:
- A **standalone stdio MCP server** (`mcp-server.ts`) exposing 5 tools
- A **file-based IPC bridge** (`mcp-bridge.ts`) between the extension and the MCP server
- A **global enable/disable setting** (`openblink.mcp.enabled`) with runtime toggling
- A **MCP Status sidebar view** for monitoring integration activity
- A **Cascade Hook** for automatic Build & Blink when Cascade edits `.rb` files
- Full **i18n support** (en, ja, zh-CN, zh-TW) and comprehensive **documentation**

https://github.com/user-attachments/assets/94589b8a-7da4-4fce-ae91-c7ede1e755ed

## Motivation

OpenBlink is designed for AI-assisted mruby/c development. While the extension already provides structured output (`[COMPILE]`/`[TRANSFER]`/`[DEVICE]`) for AI readability, there was no standardized way for AI agents to *actively* interact with the extension — they could read output but not trigger builds, query device state, or access board references.

MCP is the emerging cross-IDE standard for tool integration with AI agents. By shipping a built-in MCP server, OpenBlink enables AI agents across multiple IDEs to:
- Compile and transfer Ruby code to devices (`build_and_blink`)
- Query BLE connection state and device info (`get_device_info`)
- Read real-time device console output (`get_console_output`)
- Access compile/transfer performance metrics (`get_metrics`)
- Retrieve board-specific API references (`get_board_reference`)

## Architecture

```
┌─────────────────────────────────────────────────┐
│  VS Code / Windsurf Extension Host              │
│                                                 │
│  extension.ts ──► mcp-bridge.ts ──► .openblink/ │
│                                    (IPC files)  │
└─────────────────────────────────────────────────┘
                                         ▲  ▼
                                    file reads/writes
                                         ▲  ▼
┌─────────────────────────────────────────────────┐
│  MCP Server (separate Node.js process)          │
│                                                 │
│  mcp-server.ts ◄──► AI Agent (stdio)            │
└─────────────────────────────────────────────────┘
```

The extension and MCP server run as **separate processes**, communicating through JSON files in the `.openblink/` directory:

| File | Direction | Description |
|------|-----------|-------------|
| `status.json` | Extension → MCP | Connection state, metrics, board info (debounced 1s) |
| `openblink-console.log` | Extension → MCP | Last 100 device console lines (debounced 2s) |
| `trigger.json` | MCP → Extension | Build & Blink request |
| `result.json` | Extension → MCP | Build outcome |

This file-based approach ensures **cross-IDE compatibility** — the MCP server has no dependency on VS Code APIs.

## MCP Tools

| Tool | Parameters | Description |
|------|------------|-------------|
| `build_and_blink` | `file` (optional) | Compile `.rb` and transfer via BLE |
| `get_device_info` | — | BLE connection state, device name/ID, MTU |
| `get_console_output` | `lines` (optional, default 50) | Recent device console output |
| `get_metrics` | — | Compile/transfer time, program size with min/avg/max |
| `get_board_reference` | — | Selected board API reference (Markdown) |

## IDE Support

| IDE | Discovery | Setup Required |
|-----|-----------|----------------|
| **VS Code Copilot** | Automatic via `mcpServerDefinitionProviders` | None |
| **Windsurf Cascade** | Manual + auto-trigger via Cascade Hook | Add to MCP config |
| **Cursor** | Manual | Add to MCP config |
| **Cline** | Manual | Add to MCP config |

The `OpenBlink: Setup MCP Server` command generates a ready-to-paste JSON snippet for manual configuration.

## MCP Status View

A new **MCP Status** sidebar view provides real-time visibility into MCP activity:
- MCP enabled/disabled state (clickable → opens settings)
- IPC file write timestamps (`status.json`, `openblink-console.log`)
- Last build trigger request ID and timestamp
- Last build result (success/failed) with error tooltip

## Global Enable/Disable

The `openblink.mcp.enabled` setting (default `true`) controls MCP at runtime:
- **Disabled**: No IPC file writes, no trigger watcher, MCP server definition returns empty
- **Enabled**: Full IPC activity, trigger watching, MCP server auto-discovery
- Changes take effect **immediately** without reload

## Changes

### New Files
- `src/mcp-server.ts` — Standalone stdio MCP server (5 tools)
- `src/mcp-bridge.ts` — File-based IPC bridge with debounced writes
- `doc/mcp-integration.md` — Comprehensive setup and architecture guide
- `.windsurf/hooks.json` + `.windsurf/hooks/post_write_rb.sh` — Cascade auto-trigger

### Modified Files
- `src/extension.ts` — MCP bridge lifecycle, trigger callbacks, server registration, `buildAndBlink` now returns `{success, error}`
- `src/ui-manager.ts` — Console ring buffer + `McpStatusTreeProvider`
- `webpack.config.js` — Two entry points (extension + mcp-server), `DefinePlugin` for version injection
- `package.json` — Dependencies (`@modelcontextprotocol/sdk`, `zod`), setting, command, view, MCP server definition provider
- `package.nls.*.json` + `l10n/bundle.l10n.*.json` — MCP localization (en/ja/zh-CN/zh-TW)
- `doc/architecture.md` — Updated diagrams and module table
- `doc/contributing.md` — Updated source tree listing
- `doc/i18n.md` — Updated localization key reference
- `README.md` — MCP feature description and documentation link
- `.gitignore` — Added `.openblink/`

### Performance
- `status.json` writes are debounced at 1 second
- `openblink-console.log` writes are debounced at 2 seconds
- MCP server only reads files on tool invocation (no polling)
- When disabled, **zero disk I/O** occurs

## Testing

- [x] `npm run compile` — Both bundles build successfully (extension.js + mcp-server.js)
- [ ] Manual: Enable/disable `openblink.mcp.enabled` at runtime
- [ ] Manual: Run `OpenBlink: Setup MCP Server` command
- [ ] Manual: Verify MCP Status TreeView updates on connection/build events
- [ ] Manual: Test `build_and_blink` tool from an MCP client
- [ ] Manual: Test Cascade Hook auto-trigger on `.rb` file edit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
