### PR TITLE
docs: update license attribution and platform support status

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 BSD 3-Clause License
 
+Copyright (c) 2025 ViXion Inc. All Rights Reserved.
 Copyright (c) 2026 OpenBlink All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenBlink VSCode Extension brings [OpenBlink](https://github.com/OpenBlink/openb
 | Platform | BLE Support |
 |----------|-------------|
 | macOS | CoreBluetooth via noble |
-| Windows **Untested yet** | WinRT via noble |
+| Windows | WinRT via noble |
 | Linux  **Untested yet** | BlueZ via noble |
 | ChromeOS  **Untested yet** | BlueZ via Crostini (Linux container) |
 


### PR DESCRIPTION
## Summary

Update project documentation with two changes:

### 1. Add original copyright holder to LICENSE
Add the ViXion Inc. (2025) copyright notice to the LICENSE file alongside the existing OpenBlink copyright. This properly attributes the original copyright holder.

### 2. Mark Windows as tested platform
Remove the "Untested yet" label from the Windows entry in the BLE platform support table, reflecting that Windows BLE support via WinRT/noble has been verified.

## Changes
- `LICENSE`: Add `Copyright (c) 2025 ViXion Inc. All Rights Reserved.`
- `README.md`: Remove `**Untested yet**` from Windows row in platform support table
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
