### PR TITLE
fix: rename package to openblink-extension for Marketplace publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ OpenBlink VSCode Extension brings [OpenBlink](https://github.com/OpenBlink/openb
 ## Installation
 
 1. Open the Extensions view in VS Code / Windsurf (`Ctrl+Shift+X`)
-2. Search for **OpenBlink VSCode Extension**
+2. Search for **OpenBlink**
 3. Click **Install**
 
 Requires VS Code 1.96.0 or later.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "openblink-vscode-extension",
+  "name": "openblink-extension",
   "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openblink-vscode-extension",
+      "name": "openblink-extension",
       "version": "0.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openblink-vscode-extension",
+  "name": "openblink-extension",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "0.3.0",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "OpenBlink VSCode Extension",
+  "displayName": "OpenBlink",
   "description": "BLEをつかって、マイコンにプログラムをおくれます — IDEからBuild & Blink",
   "command.connectDevice": "デバイスにつなぐ",
   "command.disconnectDevice": "デバイスからはなれる",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "OpenBlink VSCode Extension",
+  "displayName": "OpenBlink",
   "description": "BLE-based microcontroller development with mruby — Build & Blink from your IDE",
   "command.connectDevice": "Connect Device",
   "command.disconnectDevice": "Disconnect Device",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "OpenBlink VSCode Extension",
+  "displayName": "OpenBlink",
   "description": "通过BLE进行微控制器开发 (mruby) — 从IDE直接 Build & Blink",
   "command.connectDevice": "连接设备",
   "command.disconnectDevice": "断开设备",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "OpenBlink VSCode Extension",
+  "displayName": "OpenBlink",
   "description": "透過BLE進行微控制器開發 (mruby) — 從IDE直接 Build & Blink",
   "command.connectDevice": "連接裝置",
   "command.disconnectDevice": "中斷連接",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ export function activate(context: vscode.ExtensionContext) {
   const statusBar = ui.createStatusBar();
   context.subscriptions.push(outputChannel, diagnosticCollection, statusBar);
 
-  const extensionVersion = vscode.extensions.getExtension('OpenBlink.openblink-vscode-extension')?.packageJSON?.version ?? 'unknown';
+  const extensionVersion = vscode.extensions.getExtension('OpenBlink.openblink-extension')?.packageJSON?.version ?? 'unknown';
   ui.log(`[SYSTEM] OpenBlink VSCode Extension v${extensionVersion} started.`);
 
   // Initialize settings


### PR DESCRIPTION
## Summary

Resolve the Marketplace publishing error:

> Error: The extension 'openblink-vscode-extension' already exists in the Marketplace.

## Changes

| File | Change |
|------|--------|
| `package.json` | `name`: `openblink-vscode-extension` → `openblink-extension` |
| `package-lock.json` | Synced automatically |
| `package.nls.*.json` (4 files) | `displayName`: `OpenBlink VSCode Extension` → `OpenBlink` |
| `src/extension.ts` | Extension ID: `OpenBlink.openblink-vscode-extension` → `OpenBlink.openblink-extension` |
| `README.md` | Installation search name updated to match displayName |

## Result

- **Marketplace ID**: `OpenBlink.openblink-extension`
- **User-facing name**: **OpenBlink**
- GitHub repository URL, documentation references, and log messages remain unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
