### PR TITLE
ci: add explicit compile step before packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Test
         run: xvfb-run -a npm test
 
+      - name: Compile
+        run: npm run compile
+
       - name: Package VSIX
         run: npx @vscode/vsce package
 


### PR DESCRIPTION
Fixes missing webpack build in release workflow, which caused 'command not found' errors in published extension.

- Added explicit `npm run compile` step before `vsce package`
- Ensures `out/extension.js` is properly built before packaging

Co-authored-by: Windsurf Cascade <cascade@windsurf.ai>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
