### PR TITLE
Refactor: Use platform-specific VSIX builds for native module support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4
@@ -79,14 +77,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify native binding (macOS)
-        if: startsWith(matrix.target, 'darwin-')
-        run: |
-          echo "Noble native binding:"
-          ls -la node_modules/@abandonware/noble/build/Release/binding.node
-
-      - name: Verify native binding (Windows)
-        if: startsWith(matrix.target, 'win32-')
+      - name: Verify native binding
         shell: bash
         run: |
           echo "Noble native binding:"
@@ -140,7 +131,7 @@ jobs:
       - name: Publish to VS Code Marketplace
         id: vsce
         continue-on-error: true
-        run: npx @vscode/vsce publish --packagePath $(find . -iname '*.vsix')
+        run: npx @vscode/vsce publish --packagePath *.vsix
         env:
           VSCE_PAT: ${{ secrets.AZURE_PAT }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,83 +6,8 @@ on:
       - 'v*'
 
 jobs:
-  build-native-bindings:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Use Node.js 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install Python (Windows only)
-        if: matrix.os == 'windows-latest'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      - name: Install VS Build Tools (Windows only)
-        if: matrix.os == 'windows-latest'
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build native bindings (non-Linux)
-        if: matrix.os != 'ubuntu-latest'
-        run: npx node-gyp rebuild -C node_modules/@abandonware/noble
-
-      - name: Package native bindings
-        shell: bash
-        run: |
-          mkdir -p noble-native
-          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            # Linux uses HCI socket (pure JS), no native bindings needed
-            echo "Linux uses pure JS HCI socket, no native bindings"
-            echo "SKIP_UPLOAD=1" >> $GITHUB_ENV
-          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
-            # macOS uses native binding at lib/mac/native/binding.node
-            mkdir -p noble-native/lib/mac/native
-            cp node_modules/@abandonware/noble/lib/mac/native/binding.node noble-native/lib/mac/native/
-            if [ ! -f noble-native/lib/mac/native/binding.node ]; then
-              echo "ERROR: macOS native binding not found"
-              exit 1
-            fi
-            echo "macOS native bindings:"
-            ls -la noble-native/lib/mac/native/
-          elif [ "${{ matrix.os }}" = "windows-latest" ]; then
-            # Windows uses native binding at lib/win/native/binding.node
-            mkdir -p noble-native/lib/win/native
-            cp node_modules/@abandonware/noble/lib/win/native/binding.node noble-native/lib/win/native/
-            if [ ! -f noble-native/lib/win/native/binding.node ]; then
-              echo "ERROR: Windows native binding not found"
-              exit 1
-            fi
-            echo "Windows native bindings:"
-            ls -la noble-native/lib/win/native/
-          fi
-
-      - name: Upload native bindings artifact
-        if: env.SKIP_UPLOAD != '1'
-        uses: actions/upload-artifact@v4
-        with:
-          name: native-${{ matrix.os }}
-          path: noble-native/
-
-  release:
-    needs: build-native-bindings
+  build-wasm:
     runs-on: ubuntu-latest
-    environment: production
-    permissions:
-      contents: write
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,12 +26,47 @@ jobs:
         with:
           ruby-version: '3.3'
 
+      - name: Build mrbc WASM
+        run: make mrbc
+
+      - name: Verify mrbc WASM output
+        run: |
+          ls -la resources/wasm/mrbc.js
+          ls -la resources/wasm/mrbc.wasm
+
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm
+          path: resources/wasm/
+
+  build:
+    needs: build-wasm
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: darwin-arm64
+          - os: macos-13
+            target: darwin-x64
+          - os: windows-latest
+            target: win32-x64
+          - os: ubuntu-latest
+            target: linux-x64
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Verify version consistency
+        shell: bash
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           PKG_VERSION=$(node -p "require('./package.json').version")
@@ -116,72 +76,81 @@ jobs:
           fi
           echo "Version: $TAG_VERSION"
 
-      - name: Build mrbc WASM
-        run: make mrbc
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Verify mrbc WASM output
+      - name: Verify native binding (macOS)
+        if: startsWith(matrix.target, 'darwin-')
         run: |
-          ls -la resources/wasm/mrbc.js
-          ls -la resources/wasm/mrbc.wasm
+          echo "Noble native binding:"
+          ls -la node_modules/@abandonware/noble/build/Release/binding.node
 
-      - name: Download all native bindings
+      - name: Verify native binding (Windows)
+        if: startsWith(matrix.target, 'win32-')
+        shell: bash
+        run: |
+          echo "Noble native binding:"
+          ls -la node_modules/@abandonware/noble/build/Release/binding.node
+
+      - name: Download WASM artifact
         uses: actions/download-artifact@v4
         with:
-          path: native-artifacts
-
-      - name: Merge native bindings into node_modules
-        run: |
-          mkdir -p node_modules/@abandonware/noble/lib
-          
-          # Merge macOS bindings
-          if [ -d "native-artifacts/native-macos-latest" ]; then
-            cp -r native-artifacts/native-macos-latest/* node_modules/@abandonware/noble/
-            echo "macOS bindings merged"
-          else
-            echo "WARNING: macOS artifact not found"
-          fi
-          
-          # Merge Windows bindings
-          if [ -d "native-artifacts/native-windows-latest" ]; then
-            cp -r native-artifacts/native-windows-latest/* node_modules/@abandonware/noble/
-            echo "Windows bindings merged"
-          else
-            echo "WARNING: Windows artifact not found"
-          fi
-          
-          # Verify merged bindings
-          echo "Merged native bindings:"
-          find node_modules/@abandonware/noble/lib -name "*.node" 2>/dev/null || echo "No .node files found"
-          
-          # Verify at least one binding exists
-          if ! find node_modules/@abandonware/noble/lib -name "*.node" 2>/dev/null | grep -q .; then
-            echo "ERROR: No native bindings found after merge"
-            exit 1
-          fi
+          name: wasm
+          path: resources/wasm/
 
       - name: Lint
+        if: matrix.target == 'linux-x64'
         run: npm run lint
 
       - name: Test
+        if: matrix.target == 'linux-x64'
         run: xvfb-run -a npm test
 
-      - name: Compile
-        run: npm run compile
-
       - name: Package VSIX
-        run: npx @vscode/vsce package
+        run: npx @vscode/vsce package --target ${{ matrix.target }}
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vsix-${{ matrix.target }}
+          path: "*.vsix"
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: write
+
+    steps:
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Download all VSIX artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: vsix-*
+          merge-multiple: true
+
+      - name: List VSIX files
+        run: ls -la *.vsix
 
       - name: Publish to VS Code Marketplace
         id: vsce
         continue-on-error: true
-        run: npx @vscode/vsce publish --packagePath *.vsix
+        run: npx @vscode/vsce publish --packagePath $(find . -iname '*.vsix')
         env:
           VSCE_PAT: ${{ secrets.AZURE_PAT }}
 
       - name: Publish to Open VSX
         id: ovsx
         continue-on-error: true
-        run: npx ovsx publish *.vsix
+        run: |
+          for vsix in *.vsix; do
+            npx ovsx publish "$vsix"
+          done
         env:
           OVSX_PAT: ${{ secrets.OPEN_VSX_PAT }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,78 @@ on:
       - 'v*'
 
 jobs:
+  build-native-bindings:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Python (Windows only)
+        if: matrix.os == 'windows-latest'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install VS Build Tools (Windows only)
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build native bindings (non-Linux)
+        if: matrix.os != 'ubuntu-latest'
+        run: npx node-gyp rebuild -C node_modules/@abandonware/noble
+
+      - name: Package native bindings
+        shell: bash
+        run: |
+          mkdir -p noble-native
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            # Linux uses HCI socket (pure JS), no native bindings needed
+            echo "Linux uses pure JS HCI socket, no native bindings"
+            echo "SKIP_UPLOAD=1" >> $GITHUB_ENV
+          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+            # macOS uses native binding at lib/mac/native/binding.node
+            mkdir -p noble-native/lib/mac/native
+            cp node_modules/@abandonware/noble/lib/mac/native/binding.node noble-native/lib/mac/native/
+            if [ ! -f noble-native/lib/mac/native/binding.node ]; then
+              echo "ERROR: macOS native binding not found"
+              exit 1
+            fi
+            echo "macOS native bindings:"
+            ls -la noble-native/lib/mac/native/
+          elif [ "${{ matrix.os }}" = "windows-latest" ]; then
+            # Windows uses native binding at lib/win/native/binding.node
+            mkdir -p noble-native/lib/win/native
+            cp node_modules/@abandonware/noble/lib/win/native/binding.node noble-native/lib/win/native/
+            if [ ! -f noble-native/lib/win/native/binding.node ]; then
+              echo "ERROR: Windows native binding not found"
+              exit 1
+            fi
+            echo "Windows native bindings:"
+            ls -la noble-native/lib/win/native/
+          fi
+
+      - name: Upload native bindings artifact
+        if: env.SKIP_UPLOAD != '1'
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.os }}
+          path: noble-native/
+
   release:
+    needs: build-native-bindings
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -53,8 +124,40 @@ jobs:
           ls -la resources/wasm/mrbc.js
           ls -la resources/wasm/mrbc.wasm
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Download all native bindings
+        uses: actions/download-artifact@v4
+        with:
+          path: native-artifacts
+
+      - name: Merge native bindings into node_modules
+        run: |
+          mkdir -p node_modules/@abandonware/noble/lib
+          
+          # Merge macOS bindings
+          if [ -d "native-artifacts/native-macos-latest" ]; then
+            cp -r native-artifacts/native-macos-latest/* node_modules/@abandonware/noble/
+            echo "macOS bindings merged"
+          else
+            echo "WARNING: macOS artifact not found"
+          fi
+          
+          # Merge Windows bindings
+          if [ -d "native-artifacts/native-windows-latest" ]; then
+            cp -r native-artifacts/native-windows-latest/* node_modules/@abandonware/noble/
+            echo "Windows bindings merged"
+          else
+            echo "WARNING: Windows artifact not found"
+          fi
+          
+          # Verify merged bindings
+          echo "Merged native bindings:"
+          find node_modules/@abandonware/noble/lib -name "*.node" 2>/dev/null || echo "No .node files found"
+          
+          # Verify at least one binding exists
+          if ! find node_modules/@abandonware/noble/lib -name "*.node" 2>/dev/null | grep -q .; then
+            echo "ERROR: No native bindings found after merge"
+            exit 1
+          fi
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   build-wasm:
     runs-on: ubuntu-latest
@@ -78,6 +81,7 @@ jobs:
         run: npm ci
 
       - name: Verify native binding
+        if: runner.os != 'Linux'
         shell: bash
         run: |
           echo "Noble native binding:"
@@ -131,7 +135,7 @@ jobs:
       - name: Publish to VS Code Marketplace
         id: vsce
         continue-on-error: true
-        run: npx @vscode/vsce publish --packagePath *.vsix
+        run: npx @vscode/vsce@3 publish --packagePath *.vsix
         env:
           VSCE_PAT: ${{ secrets.AZURE_PAT }}
 
@@ -139,9 +143,11 @@ jobs:
         id: ovsx
         continue-on-error: true
         run: |
+          failed=0
           for vsix in *.vsix; do
-            npx ovsx publish "$vsix"
+            npx ovsx@0 publish "$vsix" || failed=1
           done
+          [ "$failed" -eq 0 ]
         env:
           OVSX_PAT: ${{ secrets.OPEN_VSX_PAT }}
 

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,6 +7,9 @@ resources/wasm/**
 resources/boards/**
 node_modules/**
 !node_modules/@abandonware/**
+!node_modules/@abandonware/noble/lib/mac/native/**
+!node_modules/@abandonware/noble/lib/win/native/**
+!node_modules/node-gyp-build/**
 .gitmodules
 .github/**
 doc/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,9 +7,9 @@ resources/wasm/**
 resources/boards/**
 node_modules/**
 !node_modules/@abandonware/**
-!node_modules/@abandonware/noble/lib/mac/native/**
-!node_modules/@abandonware/noble/lib/win/native/**
 !node_modules/node-gyp-build/**
+!node_modules/debug/**
+!node_modules/ms/**
 .gitmodules
 .github/**
 doc/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the OpenBlink VSCode Extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.2] - 2026-04-15
+
+### Changed
+- **Platform-specific VSIX builds** — Release pipeline now produces separate VSIX files per platform (`darwin-arm64`, `darwin-x64`, `win32-x64`, `linux-x64`) following [VS Code official guidance](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions), ensuring correct native BLE bindings are included for each OS
+- **3-job release pipeline** — Restructured `release.yml` into `build-wasm` → `build` (matrix ×4) → `publish` stages
+- **GitHub Release** — All platform-specific VSIX files are attached to each release
+
+### Fixed
+- Skip native binding verification on Linux (noble uses pure JS HCI socket, no `binding.node`)
+- Open VSX publish loop now attempts all platforms even if one fails
+- Pin `npx` tool versions (`@vscode/vsce@3`, `ovsx@0`) for reproducible CI builds
+- Add top-level `permissions: contents: read` to release workflow (least privilege)
+- Include `debug` and `ms` in VSIX (runtime dependencies of `@abandonware/noble`)
+
 ## [0.3.0] - 2026-04-13
 
 ### Added
@@ -56,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - Initial release with basic Build & Blink functionality over BLE
 
+[0.3.2]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.1...v0.3.2
 [0.3.0]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/OpenBlink/openblink-vscode-extension/releases/tag/v0.1.5

--- a/doc/build-system.md
+++ b/doc/build-system.md
@@ -90,6 +90,73 @@ Upgraded from Emscripten 4.0.23. Key changes:
 - **5.0.3**: `FS.write` only accepts TypedArray
 - **5.0.5**: C++ exceptions always thrown as CppException objects
 
+## Platform-Specific VSIX Packaging
+
+The extension uses **platform-specific VSIX builds** to include the correct native BLE bindings for each OS. This follows the [VS Code official guidance](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions) (supported since VS Code 1.61.0).
+
+### Why Platform-Specific?
+
+`@abandonware/noble` compiles a native `.node` binding via `node-gyp` during `npm ci`. The binding is OS-specific:
+
+| Platform | Native Binding | Loaded by |
+|----------|---------------|-----------|
+| macOS (arm64 / x64) | CoreBluetooth (`binding.node`) | `node-gyp-build` → `build/Release/binding.node` |
+| Windows (x64) | WinRT (`binding.node`) | `node-gyp-build` → `build/Release/binding.node` |
+| Linux (x64) | None (pure JS HCI socket) | `@abandonware/bluetooth-hci-socket` via BlueZ/D-Bus |
+
+Since `build/Release/` can only hold one platform's binary, a universal VSIX is not possible.
+
+### Release Pipeline (3-Job)
+
+```mermaid
+graph LR
+    A["build-wasm<br/>(ubuntu)"] --> B1["build<br/>(macOS-latest)"]
+    A --> B2["build<br/>(macOS-13)"]
+    A --> B3["build<br/>(windows)"]
+    A --> B4["build<br/>(ubuntu)"]
+    B1 --> C["publish"]
+    B2 --> C
+    B3 --> C
+    B4 --> C
+```
+
+| Job | Runner | Output |
+|-----|--------|--------|
+| `build-wasm` | ubuntu-latest | `mrbc.js` + `mrbc.wasm` |
+| `build` (×4) | matrix per OS | Platform-specific `.vsix` file |
+| `publish` | ubuntu-latest | Publish all VSIXs to Marketplace, Open VSX, GitHub Release |
+
+Each `build` job runs `npm ci` on its native OS, which compiles the correct `binding.node`. Then `vsce package --target <platform>` produces a VSIX containing only that platform's binary.
+
+### User Experience
+
+End users do not need to be aware of the platform-specific packaging. VS Code Marketplace and Open VSX automatically serve the correct VSIX for the user's platform. The install experience is identical to any other extension.
+
+For manual `.vsix` installation from GitHub Releases, users should select the file matching their platform (e.g., `openblink-darwin-arm64-x.y.z.vsix`).
+
+### Local Packaging
+
+```bash
+# Package for the current platform
+npx @vscode/vsce package --target darwin-arm64   # macOS Apple Silicon
+npx @vscode/vsce package --target darwin-x64     # macOS Intel
+npx @vscode/vsce package --target win32-x64      # Windows
+npx @vscode/vsce package --target linux-x64      # Linux
+```
+
+### Runtime Dependencies in VSIX
+
+Noble's runtime dependencies are explicitly unignored in `.vscodeignore`:
+
+| Dependency | Purpose | Needed at runtime? |
+|------------|---------|-------------------|
+| `@abandonware/noble` | BLE library + `build/Release/binding.node` | ✅ Yes |
+| `node-gyp-build` | Locates and loads `.node` binary | ✅ Yes |
+| `debug` | Logging in noble's JS code | ✅ Yes |
+| `ms` | Dependency of `debug` | ✅ Yes |
+| `node-addon-api` | C++ headers for `node-gyp` compilation | ❌ Build-time only |
+| `napi-thread-safe-callback` | C++ headers for `node-gyp` compilation | ❌ Build-time only |
+
 ## Clean and Rebuild
 
 ```bash

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -126,7 +126,7 @@ See [Architecture — MCP Integration](architecture.md#data-flow-mcp-integration
 
 ## Releasing
 
-Releases are automated via GitHub Actions. Pushing a version tag triggers the workflow.
+Releases are automated via GitHub Actions. Pushing a version tag triggers the workflow, which builds **platform-specific VSIX files** and publishes them to all distribution channels.
 
 ### Prerequisites
 
@@ -145,21 +145,36 @@ git tag v<VERSION>
 git push origin v<VERSION>
 ```
 
-The CI pipeline (`.github/workflows/release.yml`) will automatically:
-- Build mrbc WASM from source
-- Run lint and tests
-- Package the VSIX
-- Publish to **VS Code Marketplace**
-- Publish to **Open VSX**
-- Create a **GitHub Release** with the VSIX attached
+### Release Pipeline
+
+The CI pipeline (`.github/workflows/release.yml`) runs a 3-job workflow:
+
+1. **`build-wasm`** — Builds mrbc WASM from source (Emscripten + Ruby)
+2. **`build`** (matrix ×4) — Runs `npm ci` on each OS to compile native BLE bindings, then `vsce package --target <platform>` to create platform-specific VSIXs:
+   - `darwin-arm64` (macOS Apple Silicon)
+   - `darwin-x64` (macOS Intel)
+   - `win32-x64` (Windows)
+   - `linux-x64` (Linux)
+3. **`publish`** — Downloads all VSIXs and publishes to:
+   - **VS Code Marketplace** (`vsce publish --packagePath *.vsix`)
+   - **Open VSX** (per-file loop)
+   - **GitHub Release** (all VSIX files attached)
+
+Lint and tests run on the Linux matrix runner.
+
+### User Experience
+
+End users do not need to be aware of the platform-specific packaging. VS Code Marketplace and Open VSX automatically serve the correct VSIX for the user's platform. For manual installation from GitHub Releases, users should select the file matching their platform.
+
+See [Build System — Platform-Specific VSIX Packaging](build-system.md#platform-specific-vsix-packaging) for technical details.
 
 ### Manual Release (if needed)
 
 ```bash
 npm run compile
-npx @vscode/vsce package
+npx @vscode/vsce package --target darwin-arm64   # or other target
 npx @vscode/vsce publish --packagePath *.vsix
-npx ovsx publish *.vsix -p <OVSX_PAT>
+npx ovsx publish <file>.vsix -p <OVSX_PAT>
 ```
 
 ## Adding a New Board

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openblink-extension",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openblink-extension",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@abandonware/noble": "^1.9.2-26",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openblink-extension",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "engines": {
     "vscode": "^1.96.0"
   },


### PR DESCRIPTION
## Summary

Replace the single-VSIX approach with the official **platform-specific extension** pattern (`vsce package --target`) recommended by VS Code.

## Problem

The previous release workflow attempted to build native bindings on multiple OS runners, then merge them into a single universal VSIX. This approach had a fundamental flaw:

**`node-gyp-build` loads `.node` binaries from `build/Release/` (first priority), not from `lib/mac/native/` or `lib/win/native/`.**

The previous workflow copied bindings into `lib/*/native/` paths, which `node-gyp-build` never checks at runtime. Additionally, `build/Release/` can only hold one platform's binding at a time, making a universal VSIX impossible with this module.

## Investigation Findings

### `node-gyp-build` loading order (`node-gyp-build/node-gyp-build.js`)
1. `build/Release/*.node` — **checked first**
2. `build/Debug/*.node`
3. `prebuilds/<platform>-<arch>/` — checked if no build directory match

### `@abandonware/noble` binding resolution (`lib/resolve-bindings.js`)
- **macOS**: `lib/mac/bindings.js` → `require('node-gyp-build')(dir)` → loads `build/Release/binding.node`
- **Windows**: `lib/win/bindings.js` → `require('node-gyp-build')(dir)` → loads `build/Release/binding.node`
- **Linux**: `lib/hci-socket/bindings.js` → pure JS (no native binding needed)

### Noble's runtime dependencies
- `node-gyp-build` — **required** (loads `.node` binary at runtime)
- `debug` — **required** (used in noble's JS code)
- `ms` — **required** (dependency of `debug`)
- `node-addon-api`, `napi-thread-safe-callback` — compile-time only, NOT needed at runtime

### VS Code official recommendation
- [Publishing Extensions - Platform-specific extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions)
- [Official sample repository](https://github.com/microsoft/vscode-platform-specific-sample)

VS Code supports platform-specific extensions since v1.61.0. Each target gets its own VSIX with `vsce package --target <platform>-<arch>`, and VS Code automatically installs the correct one.

## Changes

### `release.yml` — Complete rewrite with 3-job pipeline

| Job | Runner | Purpose |
|-----|--------|---------|
| `build-wasm` | ubuntu-latest | Build mrbc WASM (Emscripten + Ruby) |
| `build` | matrix per target | `npm ci` compiles noble natively, `vsce package --target` |
| `publish` | ubuntu-latest | Collect all VSIXs, publish to Marketplace / Open VSX / GitHub |

**Target matrix:**
| Target | Runner | Native binding |
|--------|--------|----------------|
| `darwin-arm64` | `macos-latest` | CoreBluetooth (compiled by npm ci) |
| `darwin-x64` | `macos-13` | CoreBluetooth (compiled by npm ci) |
| `win32-x64` | `windows-latest` | WinRT (compiled by npm ci) |
| `linux-x64` | `ubuntu-latest` | None (pure JS HCI socket) |

### `.vscodeignore` — Fix runtime dependency handling

- **Removed**: `!node_modules/@abandonware/noble/lib/mac/native/**` and `lib/win/native/**` (incorrect paths that `node-gyp-build` never checks)
- **Restored**: `!node_modules/debug/**` and `!node_modules/ms/**` (runtime deps of noble, incorrectly removed in previous commit)
- **Kept**: `!node_modules/@abandonware/**` (includes `build/Release/binding.node`) and `!node_modules/node-gyp-build/**`

## User Experience

**End users do not need to be aware of the platform-specific packaging.** The VS Code Marketplace and Open VSX both natively support platform-specific extensions. When a user installs the extension from the Marketplace or Open VSX, VS Code automatically selects and downloads the correct VSIX for their platform. The install experience is identical to any other extension.

For users who manually download `.vsix` files from the **GitHub Release** (e.g., for offline installation), all platform-specific VSIX files (`darwin-arm64`, `darwin-x64`, `win32-x64`, `linux-x64`) are attached to each release. Users should select the file matching their platform.

## References

- https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions
- https://github.com/microsoft/vscode-platform-specific-sample
- https://github.com/prebuild/node-gyp-build