### PR TITLE
fix: replace deprecated macos-13 runner with macos-15 + Rosetta 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,9 @@ jobs:
         include:
           - os: macos-latest
             target: darwin-arm64
-          - os: macos-13
+          - os: macos-15
             target: darwin-x64
+            node_arch: x64
           - os: windows-latest
             target: win32-x64
           - os: ubuntu-latest
@@ -65,6 +66,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          architecture: ${{ matrix.node_arch || '' }}
 
       - name: Verify version consistency
         shell: bash


### PR DESCRIPTION
## Problem

The `macos-13` runner was [retired by GitHub Actions in December 2025](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/), causing the `build (macos-13, darwin-x64)` job to fail with:

```
The configuration 'macos-13-us-default' is not supported
```

This blocked the v0.3.2 release.

## Fix

Replace `macos-13` with `macos-15` (arm64) and use `actions/setup-node@v4` with `architecture: x64` to install x64 Node.js via Rosetta 2. This ensures `npm ci` compiles the correct x64 native bindings for the `darwin-x64` VSIX.

| Before | After |
|--------|-------|
| `macos-13` (x86_64 native) | `macos-15` (arm64) + Rosetta 2 x64 Node.js |

The `node_arch` matrix parameter is only set for `darwin-x64`; other targets use the runner's default architecture.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
