### PR TITLE
improve: CI workflows and VSIX packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,11 +168,11 @@ jobs:
       - name: Publish summary
         if: ${{ !cancelled() }}
         run: |
-          echo "## Publish Results" >> $GITHUB_STEP_SUMMARY
-          echo "| Channel | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|---------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| VS Code Marketplace | ${{ steps.vsce.outcome }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Open VSX | ${{ steps.ovsx.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "## Publish Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Channel | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| VS Code Marketplace | ${{ steps.vsce.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Open VSX | ${{ steps.ovsx.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.vsce.outcome }}" = "failure" ]; then
             echo "::warning::VS Code Marketplace publish failed"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,13 @@ jobs:
       - name: List VSIX files
         run: ls -la *.vsix
 
+      - name: Install publish tools
+        run: npm install -g @vscode/vsce@3 ovsx@0
+
       - name: Publish to VS Code Marketplace
         id: vsce
         continue-on-error: true
-        run: npx @vscode/vsce@3 publish --packagePath *.vsix
+        run: vsce publish --packagePath *.vsix
         env:
           VSCE_PAT: ${{ secrets.AZURE_PAT }}
 
@@ -147,25 +150,32 @@ jobs:
         run: |
           failed=0
           for vsix in *.vsix; do
-            npx ovsx@0 publish "$vsix" || failed=1
+            ovsx publish "$vsix" || failed=1
           done
           [ "$failed" -eq 0 ]
         env:
           OVSX_PAT: ${{ secrets.OPEN_VSX_PAT }}
 
-      - name: Verify publish results
-        if: steps.vsce.outcome == 'failure' || steps.ovsx.outcome == 'failure'
-        run: |
-          echo "::error::One or more publish steps failed"
-          [ "${{ steps.vsce.outcome }}" = "failure" ] && echo "::error::VS Code Marketplace publish failed"
-          [ "${{ steps.ovsx.outcome }}" = "failure" ] && echo "::error::Open VSX publish failed"
-          exit 1
-
       - name: Create GitHub Release
-        if: steps.vsce.outcome == 'success' && steps.ovsx.outcome == 'success'
+        if: ${{ !cancelled() }}
         uses: softprops/action-gh-release@v2
         with:
           files: '*.vsix'
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish summary
+        if: ${{ !cancelled() }}
+        run: |
+          echo "## Publish Results" >> $GITHUB_STEP_SUMMARY
+          echo "| Channel | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| VS Code Marketplace | ${{ steps.vsce.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Open VSX | ${{ steps.ovsx.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.vsce.outcome }}" = "failure" ]; then
+            echo "::warning::VS Code Marketplace publish failed"
+          fi
+          if [ "${{ steps.ovsx.outcome }}" = "failure" ]; then
+            echo "::warning::Open VSX publish failed"
+          fi

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -9,6 +9,9 @@ on:
       - 'vendor/mruby/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-mrbc-wasm:
     runs-on: ubuntu-latest

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,7 +6,11 @@ resources/wasm_build/**
 resources/wasm/**
 resources/boards/**
 node_modules/**
-!node_modules/@abandonware/**
+!node_modules/@abandonware/noble/package.json
+!node_modules/@abandonware/noble/index.js
+!node_modules/@abandonware/noble/lib/**/*.js
+!node_modules/@abandonware/noble/lib/**/*.json
+!node_modules/@abandonware/noble/build/Release/binding.node
 !node_modules/node-gyp-build/**
 !node_modules/debug/**
 !node_modules/ms/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,7 @@ resources/boards/**
 node_modules/**
 !node_modules/@abandonware/noble/package.json
 !node_modules/@abandonware/noble/index.js
+!node_modules/@abandonware/noble/with-custom-binding.js
 !node_modules/@abandonware/noble/lib/**/*.js
 !node_modules/@abandonware/noble/lib/**/*.json
 !node_modules/@abandonware/noble/build/Release/binding.node

--- a/doc/build-system.md
+++ b/doc/build-system.md
@@ -152,7 +152,7 @@ Noble's runtime dependencies are explicitly unignored in `.vscodeignore`:
 
 | Dependency | Included paths | Purpose |
 |------------|---------------|---------|
-| `@abandonware/noble` | `package.json`, `index.js`, `lib/**/*.js`, `lib/**/*.json`, `build/Release/binding.node` | BLE library + native addon |
+| `@abandonware/noble` | `package.json`, `index.js`, `with-custom-binding.js`, `lib/**/*.js`, `lib/**/*.json`, `build/Release/binding.node` | BLE library + native addon |
 | `node-gyp-build` | `**` | Locates and loads `.node` binary at runtime |
 | `debug` | `**` | Logging in noble's JS code |
 | `ms` | `**` | Dependency of `debug` |

--- a/doc/build-system.md
+++ b/doc/build-system.md
@@ -111,7 +111,7 @@ Since `build/Release/` can only hold one platform's binary, a universal VSIX is 
 ```mermaid
 graph LR
     A["build-wasm<br/>(ubuntu)"] --> B1["build<br/>(macOS-latest)"]
-    A --> B2["build<br/>(macOS-13)"]
+    A --> B2["build<br/>(macOS-15 + Rosetta 2)"]
     A --> B3["build<br/>(windows)"]
     A --> B4["build<br/>(ubuntu)"]
     B1 --> C["publish"]
@@ -127,6 +127,8 @@ graph LR
 | `publish` | ubuntu-latest | Publish all VSIXs to Marketplace, Open VSX, GitHub Release |
 
 Each `build` job runs `npm ci` on its native OS, which compiles the correct `binding.node`. Then `vsce package --target <platform>` produces a VSIX containing only that platform's binary.
+
+The `darwin-x64` target runs on `macos-15` (arm64) with `actions/setup-node` configured to install x64 Node.js. Rosetta 2 translates the x64 process, ensuring `node-gyp` compiles the correct x64 native binding.
 
 ### User Experience
 
@@ -148,14 +150,16 @@ npx @vscode/vsce package --target linux-x64      # Linux
 
 Noble's runtime dependencies are explicitly unignored in `.vscodeignore`:
 
-| Dependency | Purpose | Needed at runtime? |
-|------------|---------|-------------------|
-| `@abandonware/noble` | BLE library + `build/Release/binding.node` | ✅ Yes |
-| `node-gyp-build` | Locates and loads `.node` binary | ✅ Yes |
-| `debug` | Logging in noble's JS code | ✅ Yes |
-| `ms` | Dependency of `debug` | ✅ Yes |
-| `node-addon-api` | C++ headers for `node-gyp` compilation | ❌ Build-time only |
-| `napi-thread-safe-callback` | C++ headers for `node-gyp` compilation | ❌ Build-time only |
+| Dependency | Included paths | Purpose |
+|------------|---------------|---------|
+| `@abandonware/noble` | `package.json`, `index.js`, `lib/**/*.js`, `lib/**/*.json`, `build/Release/binding.node` | BLE library + native addon |
+| `node-gyp-build` | `**` | Locates and loads `.node` binary at runtime |
+| `debug` | `**` | Logging in noble's JS code |
+| `ms` | `**` | Dependency of `debug` |
+
+Build-time only dependencies (`node-addon-api`, `napi-thread-safe-callback`) and noble's C++ source files (`*.cc`, `*.h`, `*.mm`, `*.gyp`) are excluded.
+
+> **Note**: `vsce` uses flat negate semantics — a `!` pattern always overrides all ignore patterns regardless of order. To exclude build artifacts, each negate pattern must target only the specific files needed at runtime (e.g., `!noble/lib/**/*.js`) rather than broad globs (e.g., `!noble/**`).
 
 ## Clean and Rebuild
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -158,9 +158,9 @@ The CI pipeline (`.github/workflows/release.yml`) runs a 3-job workflow:
 3. **`publish`** — Downloads all VSIXs and publishes to:
    - **VS Code Marketplace** (`vsce publish --packagePath *.vsix`)
    - **Open VSX** (per-file loop)
-   - **GitHub Release** (all VSIX files attached)
+   - **GitHub Release** (all VSIX files attached, always created)
 
-Lint and tests run on the Linux matrix runner.
+Marketplace/Open VSX publish failures are non-fatal warnings — the GitHub Release is always created so VSIX files are available for manual download. Lint and tests run on the Linux matrix runner.
 
 ### User Experience
 


### PR DESCRIPTION
## Summary

Improvements to all three GitHub Actions workflows and VSIX packaging, identified from the v0.3.2 release run analysis.

## Changes

### `release.yml` — Publish resilience

| Before | After |
|--------|-------|
| `npx @vscode/vsce@3` / `npx ovsx@0` per step | `npm install -g` once, then use directly |
| GitHub Release only if both publishes succeed | GitHub Release always created (unless cancelled) |
| Fatal "Verify publish results" step | Non-fatal warnings + `GITHUB_STEP_SUMMARY` table |

This prevents the scenario from v0.3.2 where a re-run (after tag move) caused "already exists" errors that blocked the GitHub Release.

### `ci.yml` / `wasm-build.yml` — Security

Added top-level `permissions: contents: read` (least privilege) to both workflows, matching the existing pattern in `release.yml`.

### `.vscodeignore` — VSIX size optimization

Replaced `!node_modules/@abandonware/**` (unignores everything) with precise patterns:

```
!node_modules/@abandonware/noble/package.json
!node_modules/@abandonware/noble/index.js
!node_modules/@abandonware/noble/lib/**/*.js
!node_modules/@abandonware/noble/lib/**/*.json
!node_modules/@abandonware/noble/build/Release/binding.node
```

**Root cause**: `vsce` uses flat negate semantics — a `!` pattern always overrides all ignore patterns regardless of order. The broad `!node_modules/@abandonware/**` made it impossible to re-exclude build artifacts.

**Impact**:
| Metric | Before | After |
|--------|--------|-------|
| Noble files in VSIX | 137 | 27 |
| Excluded | — | `.o`, `.a`, `.cc`, `.h`, `.mm`, `.gyp`, Makefile, examples, tests, assets |
| Expected win32-x64 VSIX | ~29 MB | ~1 MB |

### Documentation

- Updated `doc/build-system.md`: Mermaid diagram (macos-15 + Rosetta 2), runtime dependency table, vsce negate semantics note
- Updated `doc/contributing.md`: GitHub Release always created, marketplace failures are non-fatal
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
