### PR TITLE
fix: include bluetooth-hci-socket in Linux VSIX for HCI socket BLE support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify native binding (macOS/Windows)
+        if: runner.os != 'Linux'
+        shell: bash
+        run: |
+          echo "Noble native binding:"
+          ls -la node_modules/@abandonware/noble/build/Release/binding.node
+
+      - name: Verify native binding (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "bluetooth-hci-socket native binding:"
+          ls -la node_modules/@abandonware/bluetooth-hci-socket/build/Release/bluetooth_hci_socket.node
+
       - name: Lint
         run: npm run lint
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,12 +82,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify native binding
+      - name: Verify native binding (macOS/Windows)
         if: runner.os != 'Linux'
         shell: bash
         run: |
           echo "Noble native binding:"
           ls -la node_modules/@abandonware/noble/build/Release/binding.node
+
+      - name: Verify native binding (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "bluetooth-hci-socket native binding:"
+          ls -la node_modules/@abandonware/bluetooth-hci-socket/build/Release/bluetooth_hci_socket.node
 
       - name: Download WASM artifact
         uses: actions/download-artifact@v4

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,6 +12,10 @@ node_modules/**
 !node_modules/@abandonware/noble/lib/**/*.js
 !node_modules/@abandonware/noble/lib/**/*.json
 !node_modules/@abandonware/noble/build/Release/binding.node
+!node_modules/@abandonware/bluetooth-hci-socket/package.json
+!node_modules/@abandonware/bluetooth-hci-socket/index.js
+!node_modules/@abandonware/bluetooth-hci-socket/lib/native.js
+!node_modules/@abandonware/bluetooth-hci-socket/build/Release/bluetooth_hci_socket.node
 !node_modules/node-gyp-build/**
 !node_modules/debug/**
 !node_modules/ms/**

--- a/doc/build-system.md
+++ b/doc/build-system.md
@@ -153,7 +153,7 @@ Noble's runtime dependencies are explicitly unignored in `.vscodeignore`:
 | Dependency | Included paths | Purpose |
 |------------|---------------|---------|
 | `@abandonware/noble` | `package.json`, `index.js`, `with-custom-binding.js`, `lib/**/*.js`, `lib/**/*.json`, `build/Release/binding.node` | BLE library + native addon |
-| `@abandonware/bluetooth-hci-socket` | `package.json`, `index.js`, `lib/native.js`, `build/Release/bluetooth_hci_socket.node` | Linux HCI socket transport (optional dep, installed only on Linux) |
+| `@abandonware/bluetooth-hci-socket` | `package.json`, `index.js`, `lib/native.js`, `build/Release/bluetooth_hci_socket.node` | Optional dependency; used by the extension for Linux HCI-socket transport |
 | `node-gyp-build` | `**` | Locates and loads `.node` binary at runtime (macOS/Windows) |
 | `debug` | `**` | Logging in noble's JS code |
 | `ms` | `**` | Dependency of `debug` |

--- a/doc/build-system.md
+++ b/doc/build-system.md
@@ -102,7 +102,7 @@ The extension uses **platform-specific VSIX builds** to include the correct nati
 |----------|---------------|-----------|
 | macOS (arm64 / x64) | CoreBluetooth (`binding.node`) | `node-gyp-build` → `build/Release/binding.node` |
 | Windows (x64) | WinRT (`binding.node`) | `node-gyp-build` → `build/Release/binding.node` |
-| Linux (x64) | None (pure JS HCI socket) | `@abandonware/bluetooth-hci-socket` via BlueZ/D-Bus |
+| Linux (x64) | HCI socket (`bluetooth_hci_socket.node`) | `@abandonware/bluetooth-hci-socket` → `build/Release/bluetooth_hci_socket.node` |
 
 Since `build/Release/` can only hold one platform's binary, a universal VSIX is not possible.
 
@@ -153,11 +153,12 @@ Noble's runtime dependencies are explicitly unignored in `.vscodeignore`:
 | Dependency | Included paths | Purpose |
 |------------|---------------|---------|
 | `@abandonware/noble` | `package.json`, `index.js`, `with-custom-binding.js`, `lib/**/*.js`, `lib/**/*.json`, `build/Release/binding.node` | BLE library + native addon |
-| `node-gyp-build` | `**` | Locates and loads `.node` binary at runtime |
+| `@abandonware/bluetooth-hci-socket` | `package.json`, `index.js`, `lib/native.js`, `build/Release/bluetooth_hci_socket.node` | Linux HCI socket transport (optional dep, installed only on Linux) |
+| `node-gyp-build` | `**` | Locates and loads `.node` binary at runtime (macOS/Windows) |
 | `debug` | `**` | Logging in noble's JS code |
 | `ms` | `**` | Dependency of `debug` |
 
-Build-time only dependencies (`node-addon-api`, `napi-thread-safe-callback`) and noble's C++ source files (`*.cc`, `*.h`, `*.mm`, `*.gyp`) are excluded.
+Build-time only dependencies (`node-addon-api`, `napi-thread-safe-callback`, `nan`, `node-gyp`, `@mapbox/node-pre-gyp`) and native C++ source files (`*.cc`, `*.h`, `*.mm`, `*.gyp`) are excluded.
 
 > **Note**: `vsce` uses flat negate semantics — a `!` pattern always overrides all ignore patterns regardless of order. To exclude build artifacts, each negate pattern must target only the specific files needed at runtime (e.g., `!noble/lib/**/*.js`) rather than broad globs (e.g., `!noble/**`).
 


### PR DESCRIPTION
## Summary

Include `@abandonware/bluetooth-hci-socket` runtime files in the Linux VSIX to enable BLE functionality via the HCI socket transport.

Closes #22

## Problem

On Linux (and ChromeOS Crostini), `@abandonware/noble` uses the HCI socket transport (`lib/hci-socket/bindings.js`), which requires `@abandonware/bluetooth-hci-socket` at runtime. This optional dependency was never included in the packaged VSIX, so **Linux users could not use BLE features at all**.

## Platform-Specific BLE Architecture

Noble uses different native transports depending on the OS:

| Platform | Transport | Native Binding | Loaded by |
|----------|-----------|---------------|-----------|
| **macOS** (arm64 / x64) | CoreBluetooth | `noble/build/Release/binding.node` | `node-gyp-build` |
| **Windows** (x64) | WinRT | `noble/build/Release/binding.node` | `node-gyp-build` |
| **Linux / ChromeOS** (x64) | HCI socket (BlueZ) | `bluetooth-hci-socket/build/Release/bluetooth_hci_socket.node` | Direct `require()` in `lib/native.js` |

### macOS & Windows

Noble compiles its own native `.node` addon during `npm ci` using `node-gyp`. The compiled binary at `build/Release/binding.node` is located at runtime by `node-gyp-build`. Both the binding and `node-gyp-build` were already included in the VSIX — these platforms were unaffected.

### Linux & ChromeOS

Noble delegates BLE to `@abandonware/bluetooth-hci-socket`, an optional dependency that provides low-level HCI socket access via BlueZ. This package:

1. Uses `@mapbox/node-pre-gyp` **at install time only** to download or compile its native binding
2. At **runtime**, `lib/native.js` directly requires `build/Release/bluetooth_hci_socket.node` — **no `node-pre-gyp` is needed**

This is the key finding: despite the Issue description mentioning `node-pre-gyp` as a runtime dependency, the actual source code shows it is install-time only. Therefore, we only need four files from `bluetooth-hci-socket` in the VSIX:

- `package.json`
- `index.js` (platform dispatcher)
- `lib/native.js` (Linux binding loader)
- `build/Release/bluetooth_hci_socket.node` (native addon)

## Changes

### `.vscodeignore`
Add negate patterns to include `bluetooth-hci-socket` runtime files. These patterns only match files that exist after `npm ci` on Linux — on macOS/Windows the package is not installed, so the patterns are harmless no-ops.

### `.github/workflows/ci.yml`
Add platform-specific native binding verification:
- **macOS/Windows**: verify `noble/build/Release/binding.node`
- **Linux**: verify `bluetooth-hci-socket/build/Release/bluetooth_hci_socket.node`

### `.github/workflows/release.yml`
Add Linux-specific verification step alongside the existing macOS/Windows check. Renamed the existing step for clarity.

### `doc/build-system.md`
- Correct the platform table: Linux uses a native `.node` binding (not "pure JS")
- Add `bluetooth-hci-socket` to the runtime dependencies table
- Clarify that `node-gyp-build` is used only on macOS/Windows
- List additional build-time-only dependencies (`nan`, `node-gyp`, `@mapbox/node-pre-gyp`)

## Testing

- CI will verify the native binding exists on each platform after `npm ci`
- Full end-to-end BLE testing on Linux hardware is required to confirm the HCI socket transport works in the packaged VSIX
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
