### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the OpenBlink VSCode Extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.3] - 2026-04-15
+
+### Fixed
+- Include `bluetooth-hci-socket` native binding in Linux VSIX for HCI socket BLE support
+- Include noble's `with-custom-binding.js` in VSIX for correct native binding resolution
+
+### Changed
+- Improve CI workflows and VSIX packaging reliability
+- Quote `$GITHUB_STEP_SUMMARY` in release workflow to avoid word-splitting
+
 ## [0.3.2] - 2026-04-15
 
 ### Changed
@@ -70,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - Initial release with basic Build & Blink functionality over BLE
 
+[0.3.3]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.1...v0.3.2
 [0.3.0]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.1.5...v0.2.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openblink-extension",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "engines": {
     "vscode": "^1.96.0"
   },


### PR DESCRIPTION
## Release v0.3.3

### Changes
- Bump version to 0.3.3

### Fixed
- Include `bluetooth-hci-socket` native binding in Linux VSIX for HCI socket BLE support
- Include noble's `with-custom-binding.js` in VSIX for correct native binding resolution

### Changed
- Improve CI workflows and VSIX packaging reliability
- Quote `$GITHUB_STEP_SUMMARY` in release workflow to avoid word-splitting

### Release Process
After merging this PR, create and push the tag:
```bash
git checkout main && git pull
git tag v0.3.3
git push origin v0.3.3
```
This will trigger the release workflow.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
