### PR TITLE
improve: clean up VSIX contents and speed up CI/release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           node-version: 20
           architecture: ${{ matrix.node_arch || '' }}
+          cache: 'npm'
 
       - name: Verify version consistency
         shell: bash
@@ -109,6 +110,15 @@ jobs:
       - name: Test
         if: matrix.target == 'linux-x64'
         run: xvfb-run -a npm test
+
+      - name: Clean build output
+        shell: bash
+        run: rm -rf out
+
+      - name: Remove unnecessary bluetooth-hci-socket (non-Linux)
+        if: runner.os != 'Linux'
+        shell: bash
+        run: rm -rf node_modules/@abandonware/bluetooth-hci-socket
 
       - name: Package VSIX
         run: npx @vscode/vsce package --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,10 +111,6 @@ jobs:
         if: matrix.target == 'linux-x64'
         run: xvfb-run -a npm test
 
-      - name: Clean build output
-        shell: bash
-        run: rm -rf out
-
       - name: Remove unnecessary bluetooth-hci-socket (non-Linux)
         if: runner.os != 'Linux'
         shell: bash

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,7 @@
 .vscode/**
 .vscode-test/**
+.vscode-test.mjs
+.windsurf/**
 src/**
 vendor/**
 resources/wasm_build/**

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -120,7 +120,7 @@ The repository ships with a Cascade Hook (`.windsurf/hooks.json`) that auto-trig
 
 The hook uses the `post_write_code` event. When Cascade writes to a `.rb` file, the script `.windsurf/hooks/post_write_rb.sh` creates a trigger file in `.openblink/`, which the extension's `FileSystemWatcher` picks up to run Build & Blink.
 
-No additional configuration is needed — the hook is included in the repository and activates automatically in Windsurf.
+No additional configuration is needed — the hook is included in the repository and activates automatically in Windsurf.  Note that `.windsurf/` is excluded from the published VSIX (Windsurf reads hooks from the workspace root, not from the extension installation directory).  End users who want the hook must copy it to their own project; see [MCP Integration — Cascade Hook](mcp-integration.md#windsurf-cascade-hook-automatic-build--blink).
 
 See [Architecture — MCP Integration](architecture.md#data-flow-mcp-integration) for details on the file-based IPC mechanism.
 

--- a/doc/mcp-integration.md
+++ b/doc/mcp-integration.md
@@ -66,7 +66,13 @@ This provides a transparent experience — Cascade simply edits Ruby code and
 the device updates instantly, without needing to explicitly call the
 `build_and_blink` MCP tool.
 
-To use this, copy the `.windsurf/` directory to your project root:
+The hook files live in the repository root so they activate automatically
+when you develop this extension itself in Windsurf.  They are **not**
+included in the published VSIX because Windsurf reads hooks from the
+workspace root, not from the extension installation directory.
+
+To use the Cascade Hook in your own project, copy the `.windsurf/`
+directory from this repository to your project root:
 
 ```
 .windsurf/

--- a/package.json
+++ b/package.json
@@ -218,7 +218,8 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "npm run clean && npm run compile",
+    "clean": "node -e \"require('fs').rmSync('out',{recursive:true,force:true})\"",
     "compile": "webpack --mode production",
     "watch": "webpack --mode development --watch",
     "compile-tests": "tsc -p .",


### PR DESCRIPTION
## Summary

Analysis of the v0.3.3 release workflow revealed several issues with VSIX contents and CI performance.

### VSIX Content Fixes

| Issue | Platform | Fix |
|-------|----------|-----|
| Extra unbundled JS files (`ble-manager.js`, `board-manager.js`, etc.) | Linux | Clean `out/` before `vsce package` — stale `tsc` output from test step was leaking into VSIX |
| Unnecessary `bluetooth-hci-socket` native binding (+102KB) | Windows | Remove `bluetooth-hci-socket` on non-Linux before packaging |
| `.vscode-test.mjs` (test config) | All | Add to `.vscodeignore` |
| `.windsurf/` (dev hooks) | All | Add to `.vscodeignore` — Windsurf reads hooks from workspace root, not extension install dir |

### CI Performance

| Platform | `npm ci` time (before) |
|----------|------------------------|
| linux-x64 | 21s |
| darwin-arm64 | 35s |
| darwin-x64 | 3m |
| **win32-x64** | **11m** ← bottleneck |

Added `cache: 'npm'` to `actions/setup-node` in both `ci.yml` and `release.yml` to cache npm dependencies across runs.

### Documentation

- Documented that `.windsurf/` is excluded from VSIX with rationale in `mcp-integration.md` and `contributing.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
