### PR TITLE
perf: speed up extension activation

### DIFF
--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -68,5 +68,6 @@
   "Saved Devices": "ほぞんしたデバイス",
   "Connected": "せつぞくずみ",
   "Connecting...": "せつぞくちゅう...",
-  "Device not found. Please scan again.": "デバイスがみつかりません。もういちどスキャンしてください。"
+  "Device not found. Please scan again.": "デバイスがみつかりません。もういちどスキャンしてください。",
+  "Failed to load Bluetooth module. BLE support may not be available on this platform.": "Bluetooth モジュールのよみこみにしっぱいしました。このプラットフォームでは BLE がつかえないかもしれません。"
 }

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -68,5 +68,6 @@
   "Saved Devices": "Saved Devices",
   "Connected": "Connected",
   "Connecting...": "Connecting...",
-  "Device not found. Please scan again.": "Device not found. Please scan again."
+  "Device not found. Please scan again.": "Device not found. Please scan again.",
+  "Failed to load Bluetooth module. BLE support may not be available on this platform.": "Failed to load Bluetooth module. BLE support may not be available on this platform."
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -68,5 +68,6 @@
   "Saved Devices": "已保存的设备",
   "Connected": "已连接",
   "Connecting...": "连接中...",
-  "Device not found. Please scan again.": "未找到设备。请重新扫描。"
+  "Device not found. Please scan again.": "未找到设备。请重新扫描。",
+  "Failed to load Bluetooth module. BLE support may not be available on this platform.": "无法加载蓝牙模块。此平台可能不支持 BLE。"
 }

--- a/l10n/bundle.l10n.zh-tw.json
+++ b/l10n/bundle.l10n.zh-tw.json
@@ -68,5 +68,6 @@
   "Saved Devices": "已儲存的裝置",
   "Connected": "已連接",
   "Connecting...": "連接中...",
-  "Device not found. Please scan again.": "找不到裝置。請重新掃描。"
+  "Device not found. Please scan again.": "找不到裝置。請重新掃描。",
+  "Failed to load Bluetooth module. BLE support may not be available on this platform.": "無法載入藍牙模組。此平台可能不支援 BLE。"
 }

--- a/src/ble-manager.ts
+++ b/src/ble-manager.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from 'vscode';
 import * as l10n from '@vscode/l10n';
-import noble, { Peripheral, Characteristic } from '@abandonware/noble';
+import type { Peripheral, Characteristic } from '@abandonware/noble';
 import {
   ConnectionState,
   DeviceInfo,
@@ -17,14 +17,48 @@ import {
 
 /**
  * @brief Extended Noble module type with runtime state properties and async scan helpers.
+ *
+ * Declared as a standalone interface (rather than `typeof noble & { ... }`) to
+ * support lazy-loading of the native noble module.  Only the subset of the
+ * Noble API actually used by {@link BleManager} is listed here.
  */
-type NobleWithState = typeof noble & {
+interface NobleWithState {
   state: 'poweredOn' | 'poweredOff' | 'unknown';
   initialized: boolean;
   scanning: boolean;
   startScanningAsync: (serviceUUIDs?: string[], allowDuplicates?: boolean) => Promise<void>;
   stopScanningAsync: () => Promise<void>;
-};
+  on(event: 'stateChange', callback: (state: string) => void): void;
+  on(event: 'discover', callback: (peripheral: Peripheral) => void): void;
+  removeListener(event: 'stateChange', callback: (state: string) => void): void;
+  removeListener(event: 'discover', callback: (peripheral: Peripheral) => void): void;
+}
+
+/** @brief Lazily resolved Noble module instance. */
+let _noble: NobleWithState | undefined;
+
+/**
+ * @brief Lazy-load the @abandonware/noble native module.
+ *
+ * Defers loading of the heavy native BLE module until BLE operations are
+ * actually requested, avoiding its cost during extension activation.
+ *
+ * @returns The Noble module cast to {@link NobleWithState}.
+ */
+function getNoble(): NobleWithState {
+  if (!_noble) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      _noble = require('@abandonware/noble') as NobleWithState;
+    } catch (error) {
+      throw new Error(
+        l10n.t('Failed to load Bluetooth module. BLE support may not be available on this platform.'),
+        { cause: error },
+      );
+    }
+  }
+  return _noble;
+}
 
 /**
  * @brief Manages BLE connectivity to OpenBlink-compatible devices.
@@ -141,20 +175,20 @@ export class BleManager {
    * @throws Error if Bluetooth initialization times out or the adapter is off.
    */
   private async ensureAdapterReady(): Promise<void> {
-    const nobleInstance = noble as NobleWithState;
-    this.log(`[BLE] Noble state: ${nobleInstance.state}`);
+    const noble = getNoble();
+    this.log(`[BLE] Noble state: ${noble.state}`);
 
-    if (nobleInstance.state === 'poweredOn') { return; }
+    if (noble.state === 'poweredOn') { return; }
 
     this.log(`[BLE] Waiting for Bluetooth adapter initialization...`);
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         noble.removeListener('stateChange', stateHandler);
-        this.log(`[BLE] Bluetooth init timeout. Current state: ${nobleInstance.state}`);
+        this.log(`[BLE] Bluetooth init timeout. Current state: ${noble.state}`);
         this.log(`[BLE] Troubleshooting: Check Bluetooth is enabled in System Settings.`);
         this.log(`[BLE] On macOS: System Settings > Privacy & Security > Bluetooth`);
         this.log(`[BLE] On Linux: Ensure BlueZ is running (sudo systemctl status bluetooth)`);
-        reject(new Error(l10n.t('Bluetooth initialization timeout') + ` (state: ${nobleInstance.state})`));
+        reject(new Error(l10n.t('Bluetooth initialization timeout') + ` (state: ${noble.state})`));
       }, BLE_CONSTANTS.BLUETOOTH_INIT_TIMEOUT);
 
       const stateHandler = (state: string) => {
@@ -173,7 +207,7 @@ export class BleManager {
       noble.on('stateChange', stateHandler);
 
       // Check again in case state changed between our check and listener registration
-      if (nobleInstance.state === 'poweredOn') {
+      if (noble.state === 'poweredOn') {
         clearTimeout(timeout);
         noble.removeListener('stateChange', stateHandler);
         resolve();
@@ -195,7 +229,7 @@ export class BleManager {
 
     await this.ensureAdapterReady();
 
-    const nobleInstance = noble as NobleWithState;
+    const noble = getNoble();
 
     // Remove our own discover listener to prevent duplicates
     this.removeDiscoverListener();
@@ -216,9 +250,9 @@ export class BleManager {
         this._onDeviceDiscovered.fire(info);
       }
     };
-    nobleInstance.on('discover', this.discoverHandler);
+    noble.on('discover', this.discoverHandler);
 
-    await nobleInstance.startScanningAsync([BLE_CONSTANTS.OPENBLINK_SERVICE_UUID]);
+    await noble.startScanningAsync([BLE_CONSTANTS.OPENBLINK_SERVICE_UUID]);
 
     this.scanTimer = setTimeout(() => {
       this.stopScan();
@@ -236,9 +270,9 @@ export class BleManager {
       this.scanTimer = null;
     }
 
-    const nobleInstance = noble as NobleWithState;
+    const noble = getNoble();
     try {
-      await nobleInstance.stopScanningAsync();
+      await noble.stopScanningAsync();
     } catch {
       // Scan may already be stopped
     }
@@ -554,7 +588,7 @@ export class BleManager {
    */
   private removeDiscoverListener(): void {
     if (this.discoverHandler) {
-      noble.removeListener('discover', this.discoverHandler);
+      getNoble().removeListener('discover', this.discoverHandler);
       this.discoverHandler = null;
     }
   }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 OpenBlink All Rights Reserved.
  */
 
-import * as fs from 'fs';
+import * as fs from 'fs/promises';
 import * as vscode from 'vscode';
 import * as l10n from '@vscode/l10n';
 import { CompileResult, CreateMrbcFactory, EmscriptenModule } from './types';
@@ -31,7 +31,7 @@ export async function initCompiler(extensionUri: vscode.Uri): Promise<void> {
   const mrbcJsPath = vscode.Uri.joinPath(extensionUri, 'out', 'mrbc.js').fsPath;
   const mrbcWasmPath = vscode.Uri.joinPath(extensionUri, 'out', 'mrbc.wasm').fsPath;
 
-  const wasmBinary = fs.readFileSync(mrbcWasmPath);
+  const wasmBinary = await fs.readFile(mrbcWasmPath);
   // Use __non_webpack_require__ to bypass webpack's static analysis for dynamic WASM module loading
   const dynamicRequire = typeof __non_webpack_require__ !== 'undefined' ? __non_webpack_require__ : require;
   const createMrbc: CreateMrbcFactory = dynamicRequire(mrbcJsPath);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -386,6 +386,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Legacy command kept for backward-compatibility; now starts a scan
     // instead of showing a QuickPick.
     vscode.commands.registerCommand('openblink.connectDevice', async () => {
+      ui.showOutputChannelOnce();
       try {
         await bleManager.startScan();
       } catch (error) {
@@ -396,6 +397,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Start scanning for OpenBlink devices (Devices view title-bar button).
     vscode.commands.registerCommand('openblink.scanDevices', async () => {
+      ui.showOutputChannelOnce();
       try {
         await bleManager.startScan();
       } catch (error) {

--- a/src/ui-manager.ts
+++ b/src/ui-manager.ts
@@ -19,12 +19,11 @@ const MAX_METRICS_HISTORY = 100;
 let outputChannel: vscode.OutputChannel;
 
 /**
- * @brief Create and show the "OpenBlink" output channel.
+ * @brief Create the "OpenBlink" output channel.
  * @returns The created {@link vscode.OutputChannel}.
  */
 export function createOutputChannel(): vscode.OutputChannel {
   outputChannel = vscode.window.createOutputChannel('OpenBlink');
-  outputChannel.show();
   return outputChannel;
 }
 
@@ -34,6 +33,21 @@ export function createOutputChannel(): vscode.OutputChannel {
  */
 export function getOutputChannel(): vscode.OutputChannel {
   return outputChannel;
+}
+
+/**
+ * @brief Reveal the output channel once, without stealing focus.
+ *
+ * Intended to be called on the first user-initiated BLE operation so that
+ * diagnostic and connection logs become visible without forcing the Output
+ * panel open during activation.
+ */
+let _outputShown = false;
+export function showOutputChannelOnce(): void {
+  if (!_outputShown && outputChannel) {
+    _outputShown = true;
+    outputChannel.show(true);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Reduce extension activation time by eliminating three performance bottlenecks in the `activate()` function.

## Changes

### 1. Stop auto-showing Output panel on activation
- Remove `outputChannel.show()` from `createOutputChannel()`
- The Output panel was forced open every time the extension activated, causing visible UI jank
- Users can still view logs via **View > Output > OpenBlink**

### 2. Lazy-load `@abandonware/noble`
- Replace the top-level `import noble from '@abandonware/noble'` with a lazy-loading getter function
- Noble is a native Node.js module that loads C++ Bluetooth bindings at `require()` time
- The `BleManager` constructor does not use Noble — it is only needed when `startScan()`, `connectById()`, etc. are invoked by user action
- `NobleWithState` is redefined as a standalone interface to avoid referencing the noble value at module scope
- Type imports (`import type { Peripheral, ... }`) are retained for compile-time checking and erased at runtime

### 3. Use async file read for WASM binary in `initCompiler`
- Replace `fs.readFileSync` with `fs.promises.readFile` for the mrbc.wasm binary
- Although `initCompiler()` was already declared `async`, the synchronous `readFileSync` blocked the extension host event loop until the entire WASM file was read from disk
- With this change, the function yields at the first `await`, allowing `activate()` to return immediately

## Safety

- **Commit 1**: Output channel is still created; all logging works unchanged
- **Commit 2**: Noble is only loaded when BLE operations are triggered; `dispose()` is safe because `discoverHandler` is non-null only if `startScan()` was already called (meaning noble is already loaded)
- **Commit 3**: `initCompiler()` is called with `.then()` in `activate()` (not awaited), so the compiler readiness timing is unchanged for user-facing operations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
