### PR TITLE
feat: sync WebIDE BLE improvements and upgrade build toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [20, 22]
+        node-version: [22]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           architecture: ${{ matrix.node_arch || '' }}
           cache: 'npm'
 
@@ -133,10 +133,10 @@ jobs:
       contents: write
 
     steps:
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Download all VSIX artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 5.0.5
+          version: 5.0.7
 
       - name: Verify Emscripten
         run: emcc --version

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 5.0.5
+          version: 5.0.7
 
       - name: Verify Emscripten
         run: emcc --version

--- a/mruby_build_config.rb
+++ b/mruby_build_config.rb
@@ -4,7 +4,7 @@ MRuby::Build.new('emscripten') do |conf|
   # Output directory for mrbc.js and mrbc.wasm
   conf.build_dir = File.expand_path('resources/wasm_build', __dir__)
 
-  # Compiler settings (Emscripten 5.0.5)
+  # Compiler settings (Emscripten 5.0.7)
   conf.cc.command = 'emcc'
   conf.cxx.command = 'em++'
   conf.linker.command = 'emcc'
@@ -18,6 +18,7 @@ MRuby::Build.new('emscripten') do |conf|
   # WebAssembly settings — target Node.js for VS Code extension
   conf.linker.flags << '-sWASM=1'
   conf.linker.flags << '-sENVIRONMENT=node'
+  conf.linker.flags << '-sWASM_BIGINT=1'              # Use BigInt for i64 (Emscripten 5.0.7)
 
   # Module settings — MODULARIZE for safe require() loading (no eval)
   conf.linker.flags << '-sMODULARIZE=1'
@@ -26,9 +27,9 @@ MRuby::Build.new('emscripten') do |conf|
 
   # Memory settings
   conf.linker.flags << '-sALLOW_MEMORY_GROWTH=1'
-  conf.linker.flags << '-sINITIAL_MEMORY=33554432'    # 32MB
+  conf.linker.flags << '-sINITIAL_HEAP=33554432'    # 32MB (INITIAL_HEAP is recommended over INITIAL_MEMORY in 5.0.7)
   conf.linker.flags << '-sMAXIMUM_MEMORY=268435456'   # 256MB
-  conf.linker.flags << '-sSTACK_SIZE=5242880'          # 5MB
+  conf.linker.flags << '-sSTACK_SIZE=5242880'         # 5MB
   conf.linker.flags << '-sMALLOC=emmalloc'
 
   # Filesystem settings — MEMFS (in-memory virtual FS, no real FS access)
@@ -36,11 +37,12 @@ MRuby::Build.new('emscripten') do |conf|
   conf.linker.flags << '-sINVOKE_RUN=0'
 
   # Performance settings
-  conf.linker.flags << '-sASSERTIONS=0'
+  conf.linker.flags << '-sASSERTIONS=0'               # Disabled for performance (default is 0 at -O1+)
   conf.linker.flags << '-sDISABLE_EXCEPTION_CATCHING=1'
+  conf.linker.flags << '-sEVAL_CTORS=1'               # Evaluate constructors at compile time (Emscripten 5.0.7)
 
   # Stability settings
-  conf.linker.flags << '-sSTACK_OVERFLOW_CHECK=1'
+  conf.linker.flags << '-sSTACK_OVERFLOW_CHECK=1'     # Security cookie with zero performance overhead
 
   # Export settings
   conf.linker.flags << '-sEXPORTED_FUNCTIONS=["_main","_malloc","_free"]'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openblink-extension",
-  "version": "0.3.2",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openblink-extension",
-      "version": "0.3.2",
+      "version": "0.3.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@abandonware/noble": "^1.9.2-26",
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
-        "@types/vscode": "^1.96.0",
+        "@types/vscode": "^1.102.0",
         "@typescript-eslint/eslint-plugin": "^8.28.0",
         "@typescript-eslint/parser": "^8.28.0",
         "@vscode/l10n-dev": "^0.0.35",
@@ -33,7 +33,7 @@
         "webpack-cli": "^7.0.2"
       },
       "engines": {
-        "vscode": "^1.96.0"
+        "vscode": "^1.102.0"
       }
     },
     "node_modules/@abandonware/bluetooth-hci-socket": {

--- a/package.json
+++ b/package.json
@@ -184,13 +184,6 @@
           "maximum": 10000,
           "description": "%config.ble.initialReconnectDelay%"
         },
-        "openblink.ble.requestedMtu": {
-          "type": "number",
-          "default": 512,
-          "minimum": 23,
-          "maximum": 1024,
-          "description": "%config.ble.requestedMtu%"
-        },
         "openblink.ble.defaultMtu": {
           "type": "number",
           "default": 20,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "%description%",
   "version": "0.3.5",
   "engines": {
-    "vscode": "^1.96.0"
+    "vscode": "^1.102.0"
   },
   "license": "BSD-3-Clause",
   "repository": {
@@ -324,7 +324,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
-    "@types/vscode": "^1.96.0",
+    "@types/vscode": "^1.102.0",
     "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",
     "@vscode/l10n-dev": "^0.0.35",

--- a/package.json
+++ b/package.json
@@ -191,6 +191,13 @@
           "maximum": 512,
           "description": "%config.ble.defaultMtu%"
         },
+        "openblink.ble.heartbeatInterval": {
+          "type": "number",
+          "default": 3000,
+          "minimum": 0,
+          "maximum": 30000,
+          "description": "%config.ble.heartbeatInterval%"
+        },
         "openblink.mcp.statusDebounce": {
           "type": "number",
           "default": 1000,

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -30,6 +30,7 @@
   "config.ble.maxReconnectAttempts": "さいせつぞくさいだいかいすう (0-20)",
   "config.ble.initialReconnectDelay": "しょきさいせつぞくおきみそく (ミリびょう、100-10000。くりかえしごとに2ばい)",
   "config.ble.defaultMtu": "MTU きょうしょうしっぱい時のきていち (バイト、7-512)",
+  "config.ble.heartbeatInterval": "BLE キープアライブ ハートビートかんかく (ミリびょう、0=むこう、0-30000)",
   "config.mcp.statusDebounce": "ステータスファイルかきこみディバウンス (ミリびょう、100-10000)",
   "config.mcp.consoleDebounce": "コンソールログファイルかきこみディバウンス (ミリびょう、100-10000)",
   "config.console.bufferSize": "コンソールにほぞんするぎょうすうじょうげん (10-1000)",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -29,7 +29,6 @@
   "config.ble.connectionTimeout": "BLE せつぞくタイムアウト (ミリびょう、1000-60000)",
   "config.ble.maxReconnectAttempts": "さいせつぞくさいだいかいすう (0-20)",
   "config.ble.initialReconnectDelay": "しょきさいせつぞくおきみそく (ミリびょう、100-10000。くりかえしごとに2ばい)",
-  "config.ble.requestedMtu": "ようきゅうする MTU サイズ (バイト、23-1024)",
   "config.ble.defaultMtu": "MTU きょうしょうしっぱい時のきていち (バイト、7-512)",
   "config.mcp.statusDebounce": "ステータスファイルかきこみディバウンス (ミリびょう、100-10000)",
   "config.mcp.consoleDebounce": "コンソールログファイルかきこみディバウンス (ミリびょう、100-10000)",

--- a/package.nls.json
+++ b/package.nls.json
@@ -29,7 +29,6 @@
   "config.ble.connectionTimeout": "BLE connection timeout in milliseconds (1000-60000)",
   "config.ble.maxReconnectAttempts": "Maximum number of automatic reconnection attempts (0-20)",
   "config.ble.initialReconnectDelay": "Initial reconnection delay in milliseconds, doubles on each retry (100-10000)",
-  "config.ble.requestedMtu": "Requested MTU size for GATT negotiation in bytes (23-1024)",
   "config.ble.defaultMtu": "Default MTU fallback value when negotiation fails in bytes (7-512)",
   "config.mcp.statusDebounce": "Status file write debounce interval in milliseconds (100-10000)",
   "config.mcp.consoleDebounce": "Console log file write debounce interval in milliseconds (100-10000)",

--- a/package.nls.json
+++ b/package.nls.json
@@ -30,6 +30,7 @@
   "config.ble.maxReconnectAttempts": "Maximum number of automatic reconnection attempts (0-20)",
   "config.ble.initialReconnectDelay": "Initial reconnection delay in milliseconds, doubles on each retry (100-10000)",
   "config.ble.defaultMtu": "Default MTU fallback value when negotiation fails in bytes (7-512)",
+  "config.ble.heartbeatInterval": "BLE keep-alive heartbeat interval in milliseconds. Set to 0 to disable (0-30000)",
   "config.mcp.statusDebounce": "Status file write debounce interval in milliseconds (100-10000)",
   "config.mcp.consoleDebounce": "Console log file write debounce interval in milliseconds (100-10000)",
   "config.console.bufferSize": "Maximum number of console output lines to retain (10-1000)",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -29,7 +29,6 @@
   "config.ble.connectionTimeout": "BLE 连接超时时间（毫秒，1000-60000）",
   "config.ble.maxReconnectAttempts": "最大自动重连次数（0-20）",
   "config.ble.initialReconnectDelay": "初始重连延迟（毫秒，100-10000，每次翻倍）",
-  "config.ble.requestedMtu": "GATT 协商请求的 MTU 大小（字节，23-1024）",
   "config.ble.defaultMtu": "协商失败时的默认 MTU 回退值（字节，7-512）",
   "config.mcp.statusDebounce": "状态文件写入防抖间隔（毫秒，100-10000）",
   "config.mcp.consoleDebounce": "控制台日志文件写入防抖间隔（毫秒，100-10000）",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -30,6 +30,7 @@
   "config.ble.maxReconnectAttempts": "最大自动重连次数（0-20）",
   "config.ble.initialReconnectDelay": "初始重连延迟（毫秒，100-10000，每次翻倍）",
   "config.ble.defaultMtu": "协商失败时的默认 MTU 回退值（字节，7-512）",
+  "config.ble.heartbeatInterval": "BLE 保活心跳间隔（毫秒，0=禁用，0-30000）",
   "config.mcp.statusDebounce": "状态文件写入防抖间隔（毫秒，100-10000）",
   "config.mcp.consoleDebounce": "控制台日志文件写入防抖间隔（毫秒，100-10000）",
   "config.console.bufferSize": "保留的最大控制台输出行数（10-1000）",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -30,6 +30,7 @@
   "config.ble.maxReconnectAttempts": "最大自動重連次數（0-20）",
   "config.ble.initialReconnectDelay": "初始重連延遲（毫秒，100-10000，每次翻倍）",
   "config.ble.defaultMtu": "協商失敗時的預設 MTU 遞補值（位元組，7-512）",
+  "config.ble.heartbeatInterval": "BLE 保活心跳間隔（毫秒，0=停用，0-30000）",
   "config.mcp.statusDebounce": "狀態檔案寫入防抖動間隔（毫秒，100-10000）",
   "config.mcp.consoleDebounce": "控制台日誌檔案寫入防抖動間隔（毫秒，100-10000）",
   "config.console.bufferSize": "保留的最大控制台輸出行數（10-1000）",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -29,7 +29,6 @@
   "config.ble.connectionTimeout": "BLE 連線逾時時間（毫秒，1000-60000）",
   "config.ble.maxReconnectAttempts": "最大自動重連次數（0-20）",
   "config.ble.initialReconnectDelay": "初始重連延遲（毫秒，100-10000，每次翻倍）",
-  "config.ble.requestedMtu": "GATT 協商請求的 MTU 大小（位元組，23-1024）",
   "config.ble.defaultMtu": "協商失敗時的預設 MTU 遞補值（位元組，7-512）",
   "config.mcp.statusDebounce": "狀態檔案寫入防抖動間隔（毫秒，100-10000）",
   "config.mcp.consoleDebounce": "控制台日誌檔案寫入防抖動間隔（毫秒，100-10000）",

--- a/src/ble-manager.ts
+++ b/src/ble-manager.ts
@@ -17,6 +17,7 @@ import {
   getBleMaxReconnectAttempts,
   getBleInitialReconnectDelay,
   getBleDefaultMtu,
+  getBleHeartbeatInterval,
 } from './types';
 
 /**
@@ -82,6 +83,10 @@ export class BleManager {
   private consoleCharacteristic: NobleCharacteristic | null = null;
   /** @brief BLE characteristic for reading the negotiated MTU. */
   private negotiatedMtuCharacteristic: NobleCharacteristic | null = null;
+  /** @brief Heartbeat timer for BLE keep-alive. */
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  /** @brief Flag to pause heartbeat during firmware transfer. */
+  private _isTransferring = false;
   /** @brief Currently connected peripheral, or null if disconnected. */
   private currentDevice: NoblePeripheral | null = null;
   /** @brief Current connection state. */
@@ -133,6 +138,8 @@ export class BleManager {
   get connectionState(): ConnectionState { return this._connectionState; }
   /** @brief Negotiated BLE MTU size in bytes. */
   get negotiatedMTU(): number { return this._negotiatedMTU; }
+  /** @brief Set transferring flag to pause heartbeat during firmware transfer. */
+  set isTransferring(value: boolean) { this._isTransferring = value; }
   /** @brief Whether a device is currently connected and ready. */
   get isConnected(): boolean { return this._connectionState === 'connected' && this.currentDevice !== null; }
   /** @brief Whether a BLE scan is currently active. */
@@ -425,6 +432,9 @@ export class BleManager {
 
     this.setConnectionState('connected');
     this.log(`[BLE] ${l10n.t('Connected to device: {0}', device.advertisement?.localName ?? 'Unknown')}`);
+
+    // Start keep-alive heartbeat
+    this.startKeepAlive();
   }
 
   /**
@@ -466,6 +476,42 @@ export class BleManager {
   }
 
   /**
+   * @brief Send a heartbeat ping to keep the BLE connection alive.
+   *
+   * Reads from the MTU characteristic to maintain communication
+   * and prevent the BLE supervision timeout from expiring.
+   */
+  private async sendHeartbeat(): Promise<void> {
+    if (!this.negotiatedMtuCharacteristic || this._isTransferring) return;
+    if (this.currentDevice?.state !== 'connected') return;
+    try {
+      await this.negotiatedMtuCharacteristic.readAsync();
+    } catch (error) {
+      this.log(`[BLE] Heartbeat failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * @brief Start the keep-alive heartbeat timer.
+   */
+  private startKeepAlive(): void {
+    this.stopKeepAlive();
+    const interval = getBleHeartbeatInterval();
+    if (interval <= 0) return; // 0 = disabled
+    this.heartbeatTimer = setInterval(() => { void this.sendHeartbeat(); }, interval);
+  }
+
+  /**
+   * @brief Stop the keep-alive heartbeat timer.
+   */
+  private stopKeepAlive(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  /**
    * @brief Handle an unexpected or user-initiated disconnection.
    *
    * Resets characteristic references and MTU. If the disconnect was
@@ -473,6 +519,7 @@ export class BleManager {
    * automatic reconnection up to the configured max reconnect attempts.
    */
   private handleDisconnect(): void {
+    this.stopKeepAlive();
     this.log(`[BLE] ${l10n.t('Device disconnected: {0}', this.deviceName)}`);
 
     this.removeConsoleListener();
@@ -539,6 +586,7 @@ export class BleManager {
    * the peripheral, and resets all internal state.
    */
   async disconnect(): Promise<void> {
+    this.stopKeepAlive();
     this.userInitiatedDisconnect = true;
     this.reconnectAttempts = getBleMaxReconnectAttempts();
 
@@ -598,6 +646,7 @@ export class BleManager {
    * emitter.  Called automatically when the extension deactivates.
    */
   async dispose(): Promise<void> {
+    this.stopKeepAlive();
     this._disposed = true;
     this.userInitiatedDisconnect = true;
     if (this.reconnectTimer) {

--- a/src/ble-manager.ts
+++ b/src/ble-manager.ts
@@ -16,7 +16,6 @@ import {
   getBleConnectionTimeout,
   getBleMaxReconnectAttempts,
   getBleInitialReconnectDelay,
-  getBleRequestedMtu,
   getBleDefaultMtu,
 } from './types';
 
@@ -431,9 +430,10 @@ export class BleManager {
   /**
    * @brief Negotiate the BLE MTU with the connected device.
    *
-   * Attempts GATT-level MTU negotiation first (`gatt.requestMTU`). If
-   * unavailable, falls back to reading the device's advertised MTU from
-   * the dedicated characteristic. On failure, resets to the configured default MTU.
+   * Uses Noble's standard `peripheral.mtu` (auto-negotiated on Linux) first.
+   * Falls back to reading the device's advertised MTU from the dedicated
+   * characteristic (Mac/Win where peripheral.mtu is null). On failure,
+   * resets to the configured default MTU.
    *
    * The final value is clamped to at least MIN_USABLE_MTU
    * to guarantee that data packets always carry at least one payload byte.
@@ -442,8 +442,10 @@ export class BleManager {
    */
   private async negotiateMTU(device: NoblePeripheral): Promise<void> {
     try {
-      if (device.gatt?.requestMTU) {
-        this._negotiatedMTU = await device.gatt.requestMTU(getBleRequestedMtu());
+      // 1. Noble standard: peripheral.mtu (Linux hci-socket auto-negotiates to 256)
+      if (device.mtu !== null && device.mtu > 0) {
+        this._negotiatedMTU = device.mtu - 3; // ATT_MTU - 3 (opcode + handle)
+      // 2. Fallback: read device-side MTU from characteristic (Mac/Win)
       } else if (this.negotiatedMtuCharacteristic) {
         const buffer = await this.negotiatedMtuCharacteristic.readAsync();
         if (buffer.length >= 2) {

--- a/src/ble-manager.ts
+++ b/src/ble-manager.ts
@@ -5,12 +5,11 @@
 
 import { EventEmitter } from 'vscode';
 import * as l10n from '@vscode/l10n';
-import type { Peripheral, Characteristic } from '@abandonware/noble';
+import type { Peripheral } from '@abandonware/noble';
 import {
   ConnectionState,
   DeviceInfo,
   NoblePeripheral,
-  NobleService,
   NobleCharacteristic,
   BLE_CONSTANTS,
   getBleScanTimeout,
@@ -382,41 +381,30 @@ export class BleManager {
     // Register disconnect handler immediately to avoid missing events during setup
     device.once('disconnect', () => this.handleDisconnect());
 
-    // Discover services
-    const services = await device.discoverServicesAsync();
-    const openBlinkService = services.find(
-      (s) => s.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_SERVICE_UUID
-    ) as NobleService | undefined;
+    // Discover services and characteristics in one call
+    const { characteristics } = await device.discoverSomeServicesAndCharacteristicsAsync(
+      [BLE_CONSTANTS.OPENBLINK_SERVICE_UUID],
+      [
+        BLE_CONSTANTS.OPENBLINK_CONSOLE_CHARACTERISTIC_UUID,
+        BLE_CONSTANTS.OPENBLINK_PROGRAM_CHARACTERISTIC_UUID,
+        BLE_CONSTANTS.OPENBLINK_MTU_CHARACTERISTIC_UUID,
+      ]
+    );
 
-    if (!openBlinkService) {
-      throw new Error(l10n.t('OpenBlink service not found'));
-    }
+    this.consoleCharacteristic =
+      (characteristics.find(
+        (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_CONSOLE_CHARACTERISTIC_UUID
+      ) as NobleCharacteristic | undefined) ?? null;
 
-    // Discover characteristics
-    const characteristics = await new Promise<Characteristic[]>((resolve, reject) => {
-      const onDiscover = (chars: Characteristic[]) => {
-        clearTimeout(timer);
-        resolve(chars);
-      };
-      const timer = setTimeout(() => {
-        openBlinkService.removeListener('characteristicsDiscover', onDiscover);
-        reject(new Error(l10n.t('Required characteristics not found')));
-      }, BLE_CONSTANTS.CHARACTERISTIC_DISCOVERY_TIMEOUT); // Not configurable - GATT protocol timing
-      openBlinkService.once('characteristicsDiscover', onDiscover);
-      openBlinkService.discoverCharacteristics();
-    });
+    this.programCharacteristic =
+      (characteristics.find(
+        (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_PROGRAM_CHARACTERISTIC_UUID
+      ) as NobleCharacteristic | undefined) ?? null;
 
-    this.consoleCharacteristic = characteristics.find(
-      (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_CONSOLE_CHARACTERISTIC_UUID
-    ) as NobleCharacteristic | undefined ?? null;
-
-    this.programCharacteristic = characteristics.find(
-      (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_PROGRAM_CHARACTERISTIC_UUID
-    ) as NobleCharacteristic | undefined ?? null;
-
-    this.negotiatedMtuCharacteristic = characteristics.find(
-      (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_MTU_CHARACTERISTIC_UUID
-    ) as NobleCharacteristic | undefined ?? null;
+    this.negotiatedMtuCharacteristic =
+      (characteristics.find(
+        (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_MTU_CHARACTERISTIC_UUID
+      ) as NobleCharacteristic | undefined) ?? null;
 
     if (!this.consoleCharacteristic || !this.programCharacteristic || !this.negotiatedMtuCharacteristic) {
       throw new Error(l10n.t('Required characteristics not found'));

--- a/src/ble-manager.ts
+++ b/src/ble-manager.ts
@@ -385,56 +385,63 @@ export class BleManager {
     this.currentDevice = device;
 
     // Register disconnect handler immediately to avoid missing events during setup
-    device.once('disconnect', () => this.handleDisconnect());
+    const disconnectHandler = () => this.handleDisconnect();
+    device.once('disconnect', disconnectHandler);
 
-    // Discover services and characteristics in one call
-    const { characteristics } = await device.discoverSomeServicesAndCharacteristicsAsync(
-      [BLE_CONSTANTS.OPENBLINK_SERVICE_UUID],
-      [
-        BLE_CONSTANTS.OPENBLINK_CONSOLE_CHARACTERISTIC_UUID,
-        BLE_CONSTANTS.OPENBLINK_PROGRAM_CHARACTERISTIC_UUID,
-        BLE_CONSTANTS.OPENBLINK_MTU_CHARACTERISTIC_UUID,
-      ]
-    );
+    try {
+      // Discover services and characteristics in one call
+      const { characteristics } = await device.discoverSomeServicesAndCharacteristicsAsync(
+        [BLE_CONSTANTS.OPENBLINK_SERVICE_UUID],
+        [
+          BLE_CONSTANTS.OPENBLINK_CONSOLE_CHARACTERISTIC_UUID,
+          BLE_CONSTANTS.OPENBLINK_PROGRAM_CHARACTERISTIC_UUID,
+          BLE_CONSTANTS.OPENBLINK_MTU_CHARACTERISTIC_UUID,
+        ]
+      );
 
-    this.consoleCharacteristic =
-      (characteristics.find(
-        (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_CONSOLE_CHARACTERISTIC_UUID
-      ) as NobleCharacteristic | undefined) ?? null;
+      this.consoleCharacteristic =
+        (characteristics.find(
+          (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_CONSOLE_CHARACTERISTIC_UUID
+        ) as NobleCharacteristic | undefined) ?? null;
 
-    this.programCharacteristic =
-      (characteristics.find(
-        (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_PROGRAM_CHARACTERISTIC_UUID
-      ) as NobleCharacteristic | undefined) ?? null;
+      this.programCharacteristic =
+        (characteristics.find(
+          (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_PROGRAM_CHARACTERISTIC_UUID
+        ) as NobleCharacteristic | undefined) ?? null;
 
-    this.negotiatedMtuCharacteristic =
-      (characteristics.find(
-        (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_MTU_CHARACTERISTIC_UUID
-      ) as NobleCharacteristic | undefined) ?? null;
+      this.negotiatedMtuCharacteristic =
+        (characteristics.find(
+          (c) => c.uuid.replace(/-/g, '') === BLE_CONSTANTS.OPENBLINK_MTU_CHARACTERISTIC_UUID
+        ) as NobleCharacteristic | undefined) ?? null;
 
-    if (!this.consoleCharacteristic || !this.programCharacteristic || !this.negotiatedMtuCharacteristic) {
-      throw new Error(l10n.t('Required characteristics not found'));
+      if (!this.consoleCharacteristic || !this.programCharacteristic || !this.negotiatedMtuCharacteristic) {
+        throw new Error(l10n.t('Required characteristics not found'));
+      }
+
+      // Remove previous console listener to prevent duplicates on reconnect
+      this.removeConsoleListener();
+
+      // Setup console notifications
+      await this.consoleCharacteristic.subscribeAsync();
+      this.consoleDataHandler = (data: Buffer) => {
+        const value = new TextDecoder().decode(data);
+        this._onConsoleOutput.fire(value);
+      };
+      this.consoleCharacteristic.on('data', this.consoleDataHandler);
+
+      // MTU negotiation
+      await this.negotiateMTU(device);
+
+      this.setConnectionState('connected');
+      this.log(`[BLE] ${l10n.t('Connected to device: {0}', device.advertisement?.localName ?? 'Unknown')}`);
+
+      // Start keep-alive heartbeat
+      this.startKeepAlive();
+    } catch (error) {
+      // Remove disconnect listener on setup failure to prevent handleDisconnect from running
+      device.removeListener('disconnect', disconnectHandler);
+      throw error;
     }
-
-    // Remove previous console listener to prevent duplicates on reconnect
-    this.removeConsoleListener();
-
-    // Setup console notifications
-    await this.consoleCharacteristic.subscribeAsync();
-    this.consoleDataHandler = (data: Buffer) => {
-      const value = new TextDecoder().decode(data);
-      this._onConsoleOutput.fire(value);
-    };
-    this.consoleCharacteristic.on('data', this.consoleDataHandler);
-
-    // MTU negotiation
-    await this.negotiateMTU(device);
-
-    this.setConnectionState('connected');
-    this.log(`[BLE] ${l10n.t('Connected to device: {0}', device.advertisement?.localName ?? 'Unknown')}`);
-
-    // Start keep-alive heartbeat
-    this.startKeepAlive();
   }
 
   /**
@@ -482,8 +489,9 @@ export class BleManager {
    * and prevent the BLE supervision timeout from expiring.
    */
   private async sendHeartbeat(): Promise<void> {
-    if (!this.negotiatedMtuCharacteristic || this._isTransferring) return;
+    if (this._connectionState !== 'connected') return;
     if (this.currentDevice?.state !== 'connected') return;
+    if (!this.negotiatedMtuCharacteristic || this._isTransferring) return;
     try {
       await this.negotiatedMtuCharacteristic.readAsync();
     } catch (error) {
@@ -519,6 +527,10 @@ export class BleManager {
    * automatic reconnection up to the configured max reconnect attempts.
    */
   private handleDisconnect(): void {
+    // Prevent duplicate execution if already disconnected or reconnecting
+    if (this._connectionState === 'disconnected' || this._connectionState === 'reconnecting') {
+      return;
+    }
     this.stopKeepAlive();
     this.log(`[BLE] ${l10n.t('Device disconnected: {0}', this.deviceName)}`);
 
@@ -567,6 +579,10 @@ export class BleManager {
         this.reconnectAttempts = 0;
         this.log(`[BLE] ${l10n.t('Reconnected successfully')}`);
       } catch {
+        // Clean up any partial BLE connection to avoid half-connected Noble state
+        if (this.currentDevice) {
+          try { await this.currentDevice.disconnectAsync(); } catch { /* ignore */ }
+        }
         if (this.reconnectAttempts < getBleMaxReconnectAttempts()) {
           this.attemptReconnect();
         } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -814,6 +814,7 @@ async function buildAndBlinkInner(
   }
 
   const transferStart = performance.now();
+  bleManager.isTransferring = true;
   try {
     await sendFirmware(programChar, result.bytecode, currentSlot, bleManager.negotiatedMTU, (msg) => ui.log(msg));
     const transferTime = performance.now() - transferStart;
@@ -862,6 +863,8 @@ async function buildAndBlinkInner(
     });
 
     return { success: false, error: msg };
+  } finally {
+    bleManager.isTransferring = false;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,8 +32,12 @@ export interface DeviceInfo {
  * and adds `connectAsync`, `disconnectAsync`, `updateRssiAsync`, and optional
  * `gatt.requestMTU` for MTU negotiation.
  */
-export type NoblePeripheral = Omit<Peripheral, 'discoverServicesAsync'> & {
+export type NoblePeripheral = Omit<Peripheral, 'discoverServicesAsync' | 'discoverSomeServicesAndCharacteristicsAsync'> & {
   discoverServicesAsync: () => Promise<NobleService[]>;
+  discoverSomeServicesAndCharacteristicsAsync: (
+    serviceUUIDs: string[],
+    characteristicUUIDs: string[]
+  ) => Promise<{ services: NobleService[]; characteristics: NobleCharacteristic[] }>;
   connectAsync: () => Promise<void>;
   disconnectAsync: () => Promise<void>;
   updateRssiAsync: () => Promise<number>;
@@ -240,8 +244,6 @@ export const BLE_CONSTANTS = {
   SCAN_TIMEOUT: 10000,
   /** @brief Timeout for the GATT connectAsync() call (ms). */
   CONNECTION_TIMEOUT: 10000,
-  /** @brief Timeout for GATT characteristic discovery after service discovery (ms). */
-  CHARACTERISTIC_DISCOVERY_TIMEOUT: 5000,
   /** @brief Timeout for the Bluetooth adapter to reach "poweredOn" state (ms). */
   BLUETOOTH_INIT_TIMEOUT: 15000,
   /** @brief Extra time added to SCAN_TIMEOUT when waiting for a saved device to appear (ms). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,6 +225,8 @@ export const BLE_CONSTANTS = {
 
   /** @brief Default MTU used when negotiation fails or is unavailable (bytes). */
   DEFAULT_MTU: 20,
+  /** @brief BLE keep-alive heartbeat interval in milliseconds (0 = disabled). */
+  HEARTBEAT_INTERVAL: 3000,
   /** @brief Size of the header prepended to each Data ('D') packet (bytes). */
   DATA_HEADER_SIZE: 6,
   /** @brief Size of the Program ('P') header packet (bytes). */
@@ -299,6 +301,14 @@ export function getBleInitialReconnectDelay(): number {
  */
 export function getBleDefaultMtu(): number {
   return vscode.workspace.getConfiguration('openblink.ble').get<number>('defaultMtu', 20);
+}
+
+/**
+ * @brief Get the configured BLE heartbeat interval from VS Code settings.
+ * @returns Heartbeat interval in milliseconds (default: 3000, 0 = disabled).
+ */
+export function getBleHeartbeatInterval(): number {
+  return vscode.workspace.getConfiguration('openblink.ble').get<number>('heartbeatInterval', 3000);
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,8 @@ export interface DeviceInfo {
  * `discoverSomeServicesAndCharacteristicsAsync` for efficient GATT discovery.
  */
 export type NoblePeripheral = Omit<Peripheral, 'discoverServicesAsync' | 'discoverSomeServicesAndCharacteristicsAsync'> & {
+  /** @brief Negotiated ATT MTU value (Linux only; null on macOS/Windows). */
+  mtu?: number | null;
   discoverServicesAsync: () => Promise<NobleService[]>;
   discoverSomeServicesAndCharacteristicsAsync: (
     serviceUUIDs: string[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,8 +29,8 @@ export interface DeviceInfo {
  * @brief Extended Noble Peripheral type with async helper methods.
  *
  * Overrides `discoverServicesAsync` to return {@link NobleService} instances
- * and adds `connectAsync`, `disconnectAsync`, `updateRssiAsync`, and optional
- * `gatt.requestMTU` for MTU negotiation.
+ * and adds `connectAsync`, `disconnectAsync`, `updateRssiAsync`, and
+ * `discoverSomeServicesAndCharacteristicsAsync` for efficient GATT discovery.
  */
 export type NoblePeripheral = Omit<Peripheral, 'discoverServicesAsync' | 'discoverSomeServicesAndCharacteristicsAsync'> & {
   discoverServicesAsync: () => Promise<NobleService[]>;
@@ -41,9 +41,6 @@ export type NoblePeripheral = Omit<Peripheral, 'discoverServicesAsync' | 'discov
   connectAsync: () => Promise<void>;
   disconnectAsync: () => Promise<void>;
   updateRssiAsync: () => Promise<number>;
-  gatt?: {
-    requestMTU: (mtu: number) => Promise<number>;
-  };
 };
 
 /**
@@ -228,8 +225,6 @@ export const BLE_CONSTANTS = {
 
   /** @brief Default MTU used when negotiation fails or is unavailable (bytes). */
   DEFAULT_MTU: 20,
-  /** @brief MTU value requested during GATT-level negotiation (bytes). */
-  REQUESTED_MTU: 512,
   /** @brief Size of the header prepended to each Data ('D') packet (bytes). */
   DATA_HEADER_SIZE: 6,
   /** @brief Size of the Program ('P') header packet (bytes). */
@@ -296,14 +291,6 @@ export function getBleMaxReconnectAttempts(): number {
  */
 export function getBleInitialReconnectDelay(): number {
   return vscode.workspace.getConfiguration('openblink.ble').get<number>('initialReconnectDelay', 1000);
-}
-
-/**
- * @brief Get the configured requested MTU from VS Code settings.
- * @returns Requested MTU in bytes (default: 512).
- */
-export function getBleRequestedMtu(): number {
-  return vscode.workspace.getConfiguration('openblink.ble').get<number>('requestedMtu', 512);
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES2022",
+    "target": "ES2024",
     "outDir": "out",
-    "lib": ["ES2022"],
+    "lib": ["ES2024"],
     "sourceMap": true,
     "rootDir": "src",
     "types": ["node", "mocha"],


### PR DESCRIPTION
## Summary

This PR synchronizes the BLE connection layer improvements from the WebIDE project and upgrades the build toolchain to current stable versions.

## Changes

### 1. BLE Connection Stability & Error Handling

**`src/ble-manager.ts`** — Major refactoring for reliability:

- **Unified GATT discovery**: Replaced separate `discoverServicesAsync` + `discoverCharacteristics` calls with `discoverSomeServicesAndCharacteristicsAsync`, eliminating a race-prone timeout-based characteristic discovery path.
- **Simplified MTU negotiation**: Removed dead `gatt.requestMTU` code path. Now uses `peripheral.mtu` (Linux hci-socket auto-negotiates to 256) as the primary source, with the device-side MTU characteristic as fallback for macOS/Windows where `peripheral.mtu` is null.
- **Keep-alive heartbeat**: Added `sendHeartbeat` / `startKeepAlive` / `stopKeepAlive` that periodically reads the MTU characteristic to prevent BLE supervision timeout expiration. Heartbeat pauses during firmware transfer (`_isTransferring` flag) to avoid interfering with data flow.
- **Duplicate disconnect guard**: `handleDisconnect` now bails out early if already `disconnected` or `reconnecting`, preventing duplicate execution.
- **Reconnect cleanup**: Failed reconnection attempts now explicitly `disconnectAsync()` the partial Noble state before retrying, avoiding half-connected peripherals.
- **Cleanup on failure**: The `setupDevice` try-catch now removes the disconnect listener on setup failure so `handleDisconnect` does not fire spuriously.
- **`src/extension.ts`**: Sets `bleManager.isTransferring = true/false` around firmware transfer to pause heartbeat.

### 2. Upgrade to Node.js 22 & VS Code 1.102.0

- `package.json`: `engines.vscode` `^1.96.0` → `^1.102.0`
- `package.json`: `@types/vscode` `^1.96.0` → `^1.102.0`
- `tsconfig.json`: `target`/`lib` `ES2022` → `ES2024`
- `.github/workflows/ci.yml`: CI matrix drops Node 20, runs only on Node 22
- `.github/workflows/release.yml`: All release jobs upgraded to Node 22

### 3. Upgrade Emscripten 5.0.5 → 5.0.7

- `.github/workflows/release.yml` & `.github/workflows/wasm-build.yml`: `5.0.5` → `5.0.7`
- **`mruby_build_config.rb`**:
  - Added `-sWASM_BIGINT=1` (i64 via BigInt, new in 5.0.7)
  - Added `-sEVAL_CTORS=1` (evaluate constructors at compile time)
  - Renamed `-sINITIAL_MEMORY` → `-sINITIAL_HEAP` (recommended in 5.0.7)
  - Added/updated comments for clarity

### 4. Settings & i18n

- **Removed** `openblink.ble.requestedMtu` setting (no longer used after MTU negotiation simplification)
- **Added** `openblink.ble.heartbeatInterval` setting (default 3000 ms, 0 = disabled)
- Updated `package.nls.{ja,zh-cn,zh-tw}.json` translations accordingly

### 5. Type Definitions

- **`src/types.ts`**:
  - Added `mtu?: number | null` to `NoblePeripheral` (Linux hci-socket)
  - Added `discoverSomeServicesAndCharacteristicsAsync` signature
  - Removed obsolete `gatt?.requestMTU` from `NoblePeripheral`
  - Replaced `REQUESTED_MTU` with `HEARTBEAT_INTERVAL` constant
  - Removed `CHARACTERISTIC_DISCOVERY_TIMEOUT` constant (no longer needed)
  - Removed `getBleRequestedMtu()`, added `getBleHeartbeatInterval()`

## Files Changed

| File | +/- |
|------|-----|
| `src/ble-manager.ts` | ~167 lines |
| `src/types.ts` | ~37 lines |
| `src/extension.ts` | +3 lines |
| `mruby_build_config.rb` | ~12 lines |
| `package.json` | ~18 lines |
| `tsconfig.json` | 4 lines |
| `.github/workflows/*.yml` | 14 lines |
| `package.nls.*.json` | 8 lines (i18n) |

## Testing Notes

- [ ] Verify BLE scan/connect/disconnect on macOS, Windows, Linux
- [ ] Verify heartbeat keeps connection alive during idle periods
- [ ] Verify firmware transfer (`Build & Blink`) still completes successfully
- [ ] Verify WASM build with Emscripten 5.0.7 produces working `mrbc.js`/`mrbc.wasm`
- [ ] Verify Node 22 CI passes on all platforms