### PR TITLE
chore: release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-05-04
+
+### Added
+- **Windows ARM64 VSIX** — Release pipeline now builds and publishes a native `win32-arm64` VSIX using the `windows-11-arm` GitHub-hosted runner, enabling first-class support on Windows ARM devices (e.g. Snapdragon X Elite).
+- **Linux ARM64 VSIX** — Release pipeline now builds and publishes a native `linux-arm64` VSIX using the `ubuntu-24.04-arm` GitHub-hosted runner (native, no emulation required).
+- **Linux ARM hard-float (armhf) VSIX** — Release pipeline now builds and publishes a `linux-armhf` VSIX for ARMv7 devices such as Raspberry Pi 3/4 running 32-bit Linux. **Note: this is a best-effort cross-build.** QEMU via `docker/setup-qemu-action` is used to emulate the ARMv7 environment, but `npm ci` still compiles native Node addons for the host (`x86_64`) architecture. As a result, the BLE native bindings (`@abandonware/noble` / `bluetooth-hci-socket`) bundled in this VSIX are built for x86_64 and **may not work** on real armhf devices. Users who encounter BLE issues on armhf should rebuild the native bindings locally (`npm rebuild`) after installing the VSIX.
+- **Dependabot for GitHub Actions** — Added `.github/dependabot.yml` to keep `actions/*` dependencies automatically up to date.
+
+### Fixed
+- **ESLint `curly` rule** — Added braces to all single-statement `if` blocks in `ble-manager.ts` to satisfy the ESLint `curly` rule, eliminating lint warnings in CI.
+
+### Changed
+- **GitHub Actions workflows overhaul** — Significant improvements to `ci.yml`, `release.yml`, and `wasm-build.yml`:
+  - `release.yml`: VSIX artifacts are now collected under a `vsix/` subdirectory for cleaner artifact handling; Marketplace and Open VSX publish loops iterate per-file with individual warning annotations on failure; GitHub Release summary is enriched with an artifacts listing table; `win32-arm64`, `linux-arm64`, and `linux-armhf` added to the build matrix (7 platforms total); version-consistency check moved from release to CI.
+  - `ci.yml`: Version-consistency check (`TAG_VERSION` vs `package.json`) now runs in the CI workflow on tag pushes, catching mismatches before the release pipeline starts.
+  - `wasm-build.yml`: Added `concurrency` group to cancel in-progress WASM builds on new pushes; added `git config core.autocrlf false` step to avoid line-ending issues on Windows runners.
+  - All workflows: Redundant blank lines and `name:` prefixes cleaned up for readability; `cache: npm` (unquoted) for consistency.
+
 ## [0.3.6] - 2026-05-04
 
 ### Added
@@ -204,6 +222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - Initial release with basic Build & Blink functionality over BLE
 
+[0.3.7]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.3...v0.3.4

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openblink-extension",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "engines": {
     "vscode": "^1.102.0"
   },


### PR DESCRIPTION
## Summary

This PR bumps the version to **v0.3.7** and updates the CHANGELOG to document all changes since v0.3.6.

---

## What changed since v0.3.6

### Added

- **Windows ARM64 VSIX** — Native `win32-arm64` VSIX via the `windows-11-arm` GitHub-hosted runner. First-class support for Windows on ARM (e.g. Snapdragon X Elite).
- **Linux ARM64 VSIX** — Native `linux-arm64` VSIX via the `ubuntu-24.04-arm` GitHub-hosted runner (no emulation required).
- **Linux armhf VSIX (best-effort)** — Cross-compiled `linux-armhf` VSIX via QEMU for ARMv7 devices (Raspberry Pi 3/4 running 32-bit Linux).
  - ⚠️ **Constraint**: `npm ci` still compiles native Node addons for the host (`x86_64`) architecture. The BLE native bindings bundled in this VSIX may not work on real armhf devices. Users who hit BLE issues should run `npm rebuild` locally after installing.
- **Dependabot for GitHub Actions** — `.github/dependabot.yml` added to keep `actions/*` versions up to date automatically.

The release pipeline now produces **7 platform-specific VSIXs** (up from 4 in v0.3.6):

| Target | Runner | Native bindings |
|---|---|---|
| `darwin-arm64` | `macos-latest` | ✅ native |
| `darwin-x64` | `macos-15` | ✅ native |
| `win32-x64` | `windows-latest` | ✅ native |
| `win32-arm64` | `windows-11-arm` | ✅ native (**new**) |
| `linux-x64` | `ubuntu-latest` | ✅ native |
| `linux-arm64` | `ubuntu-24.04-arm` | ✅ native (**new**) |
| `linux-armhf` | `ubuntu-latest` + QEMU | ⚠️ cross-build (**new**) |

### Fixed

- **ESLint `curly` rule** — Added braces to all single-statement `if` blocks in `ble-manager.ts`, eliminating lint warnings in CI.

### Changed — GitHub Actions overhaul

- **`release.yml`**: VSIX artifacts collected under `vsix/` subdirectory; per-file publish loops with individual `::warning::` annotations on failure; enriched Job Summary with artifacts table; version-consistency check moved here from individual build jobs.
- **`ci.yml`**: Version-consistency check (`TAG_VERSION` vs `package.json`) runs on tag pushes, catching mismatches before the release pipeline starts.
- **`wasm-build.yml`**: Added `concurrency` group (cancel-in-progress); added `git config core.autocrlf false`.
- All workflows: cleaned up redundant blank lines, unquoted `cache: npm` for consistency.

---

## Files changed

| File | Change |
|---|---|
| `package.json` | `version`: `0.3.6` → `0.3.7` |
| `CHANGELOG.md` | Added `[0.3.7]` section + diff link |

---

## Release checklist

- [x] `package.json` version updated to `0.3.7`
- [x] `CHANGELOG.md` updated with `[0.3.7]` section and comparison link
- [ ] PR merged to `main`
- [ ] Tag `v0.3.7` pushed → triggers Release workflow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->