### PR TITLE
fix: restore batch publish for Marketplace and add --skip-duplicate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,13 +179,7 @@ jobs:
         continue-on-error: true
         env:
           VSCE_PAT: ${{ secrets.AZURE_PAT }}
-        run: |
-          failed=0
-          for file in vsix/*.vsix; do
-            echo "Publishing $file to Marketplace..."
-            vsce publish --packagePath "$file" || { echo "::warning::Marketplace publish failed for $file"; failed=1; }
-          done
-          exit $failed
+        run: vsce publish --packagePath vsix/*.vsix --skip-duplicate
       - name: Publish to Open VSX
         id: openvsx
         continue-on-error: true
@@ -195,7 +189,7 @@ jobs:
           failed=0
           for file in vsix/*.vsix; do
             echo "Publishing $file to Open VSX..."
-            ovsx publish "$file" || { echo "::warning::Open VSX publish failed for $file"; failed=1; }
+            ovsx publish "$file" --skip-duplicate || { echo "::warning::Open VSX publish failed for $file"; failed=1; }
           done
           exit $failed
       - name: Create GitHub Release


### PR DESCRIPTION
## Problem

Two issues in the v0.3.7 release workflow:

1. **Marketplace publish changed from batch to per-file loop** (flagged in PR #43 review)
   The previous loop `for file in vsix/*.vsix; do vsce publish --packagePath "$file"; done` publishes one VSIX at a time, leaving a window where some platforms are live but others are not. The `vsce` CLI accepts multiple paths via `--packagePath <paths...>` and the docs recommend passing all files in a single call for atomicity.

2. **Re-runs fail on already-published versions**
   If the publish step is retried (e.g. after a transient error, or when the same version tag is re-pushed after a hotfix to the workflow itself), `vsce` and `ovsx` both error out on platforms that were already uploaded. Adding `--skip-duplicate` makes re-runs idempotent.

## Changes

| File | Change |
|---|---|
| `.github/workflows/release.yml` | Marketplace: restore single batch `vsce publish --packagePath vsix/*.vsix --skip-duplicate`; Open VSX: add `--skip-duplicate` to per-file loop (ovsx has no multi-file mode) |

## Before / After

**Before (per-file loop):**
```bash
for file in vsix/*.vsix; do
  vsce publish --packagePath "$file"
done
```

**After (batch):**
```bash
vsce publish --packagePath vsix/*.vsix --skip-duplicate
```

> Note: Open VSX (`ovsx`) does not support multiple paths in one call, so the loop is kept there. `--skip-duplicate` is added to make it re-run safe.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->