### PR TITLE
chore: prepare v0.3.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.8] - 2026-05-24
+
+### Changed
+- **CI dependency tooling refresh** — Updated GitHub Actions workflow dependencies (`actions/checkout@v6`, `actions/setup-node@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `docker/setup-qemu-action@v4`, `softprops/action-gh-release@v3`, `mymindstorm/setup-emsdk@v16`) and enabled `check-latest` for Node.js setup steps so CI/release jobs pick up the latest compatible Node.js 22/24 patch releases.
+- **Release runtime alignment** — Release build/test/package jobs continue to use Node.js 22 for VS Code extension host and native addon compatibility, while publisher-only jobs use Node.js 24 and the WASM build uses Ruby 3.4.
+- **Development dependency refresh** — Updated TypeScript, ESLint, webpack, VS Code test/package tooling, `ovsx`, and related type packages to newer compatible versions.
+- **MCP validation dependency upgrade** — Updated `zod` to 4.4.3.
+
+### Security
+- **Transitive dependency hardening** — Added npm overrides for `diff`, `serialize-javascript`, `tar`, `node-gyp`, and `@mapbox/node-pre-gyp` to keep vulnerable transitive packages on patched versions.
+
+### Fixed
+- **VS Code type lockfile sync** — Synced the lockfile entry for `@types/vscode` with the pinned package manifest version.
+
 ## [0.3.7] - 2026-05-04
 
 ### Added
@@ -222,6 +236,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - Initial release with basic Build & Blink functionality over BLE
 
+[0.3.8]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/OpenBlink/openblink-vscode-extension/compare/v0.3.4...v0.3.5

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -115,7 +115,7 @@ Releases are automated via GitHub Actions. Pushing a version tag triggers the wo
 
 ### Prerequisites
 
-- `VSCE_PAT` — Azure DevOps Personal Access Token with **Marketplace > Manage** scope, stored in GitHub Secrets
+- `AZURE_PAT` — Azure DevOps Personal Access Token with **Marketplace > Manage** scope, stored in GitHub Secrets and exposed to `vsce` as `VSCE_PAT`
 - `OVSX_PAT` — Open VSX access token, stored in GitHub Secrets
 
 ### Steps
@@ -132,20 +132,24 @@ git push origin v<VERSION>
 
 ### Release Pipeline
 
-The CI pipeline (`.github/workflows/release.yml`) runs a 3-job workflow:
+The release workflow (`.github/workflows/release.yml`) runs a 4-job pipeline:
 
-1. **`build-wasm`** — Builds mrbc WASM from source (Emscripten + Ruby)
-2. **`build`** (matrix ×4) — Runs `npm ci` on each OS to compile native BLE bindings, then `vsce package --target <platform>` to create platform-specific VSIXs:
+1. **`lint-and-test`** — Runs ESLint, TypeScript typecheck, version consistency validation on tags, webpack build, test compilation, and the VS Code integration test suite.
+2. **`build-wasm`** — Builds mrbc WASM from source (Emscripten + Ruby).
+3. **`build`** (matrix ×7) — Runs `npm ci` on each OS to compile native BLE bindings, then `vsce package --target <platform>` to create platform-specific VSIXs:
    - `darwin-arm64` (macOS Apple Silicon)
    - `darwin-x64` (macOS Intel)
-   - `win32-x64` (Windows)
-   - `linux-x64` (Linux)
-3. **`publish`** — Downloads all VSIXs and publishes to:
-   - **VS Code Marketplace** (`vsce publish --packagePath *.vsix`)
+   - `win32-x64` (Windows x64)
+   - `win32-arm64` (Windows ARM64)
+   - `linux-x64` (Linux x64)
+   - `linux-arm64` (Linux ARM64)
+   - `linux-armhf` (Linux ARM hard-float, best-effort cross-build)
+4. **`publish`** — Downloads all VSIXs and publishes to:
+   - **VS Code Marketplace** (`vsce publish --packagePath vsix/*.vsix`)
    - **Open VSX** (per-file loop)
    - **GitHub Release** (all VSIX files attached, always created)
 
-Marketplace/Open VSX publish failures are non-fatal warnings — the GitHub Release is always created so VSIX files are available for manual download. Lint and tests run on the Linux matrix runner.
+Marketplace/Open VSX publish failures are non-fatal warnings — the GitHub Release is always created so VSIX files are available for manual download.
 
 ### User Experience
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openblink-extension",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openblink-extension",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@abandonware/noble": "^1.9.2-26",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openblink-extension",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "engines": {
     "vscode": "^1.102.0"
   },


### PR DESCRIPTION
## Summary
- Bump extension version to 0.3.8 in package metadata
- Add v0.3.8 release notes to CHANGELOG.md based on changes since v0.3.7
- Align release documentation with the current workflow and secret naming

## Verification
- node -e "const pkg=require('./package.json'); const lock=require('./package-lock.json'); if (pkg.version !== '0.3.8') throw new Error('package.json version mismatch'); if (lock.version !== pkg.version || lock.packages[''].version !== pkg.version) throw new Error('package-lock version mismatch'); console.log('version ok:', pkg.version);"
- npm run lint
- npx tsc --noEmit -p .