### PR TITLE
ci: fix native build and vscode test paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
           node-version: 22
           check-latest: true
           cache: npm
+      - name: Configure Windows native build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: echo "CL=/D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" >> $env:GITHUB_ENV
       - name: Install dependencies
         run: npm ci
       - name: Verify native binding (macOS/Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,10 @@ jobs:
       - name: Set up QEMU (cross-build)
         if: matrix.cross
         uses: docker/setup-qemu-action@v4
+      - name: Configure Windows native build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: echo "CL=/D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" >> $env:GITHUB_ENV
       - name: Install dependencies
         run: npm ci
       - name: Verify native binding (macOS/Windows)

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,7 +1,14 @@
 import { defineConfig } from '@vscode/test-cli';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const defaultUserDataDir = process.platform === 'win32'
+  ? join(tmpdir(), `openblink-vscode-test-${process.pid}`)
+  : `/tmp/openblink-vscode-test-${process.pid}`;
 
 export default defineConfig({
   files: 'out/test/**/*.test.js',
+  launchArgs: ['--user-data-dir', process.env.VSCODE_TEST_USER_DATA_DIR ?? defaultUserDataDir],
   mocha: {
     ui: 'tdd',
     timeout: 20000,


### PR DESCRIPTION
## Summary
- Fix Windows CI native addon builds by setting the MSVC define required by newer Visual Studio toolchains before npm ci.
- Fix macOS VS Code extension tests by using a short per-process user data directory, avoiding IPC socket path length failures.
- Apply the Windows native build setup to the release VSIX build matrix as well.

## CI/CD log review
- Latest CI failures on main and Dependabot PRs shared two causes: Windows @abandonware/noble native build failed in npm ci, and macOS vscode-test failed with listen EINVAL for an overly long user-data-dir socket path.
- WASM Build and CodeQL have no recent non-success runs.
- Recent Dependabot Updates runs are passing; older failures were dependency resolution issues already covered by current overrides.
- Latest Release run is successful; historical release failures/cancellations are not current blockers.

## Testing
- npm run lint
- npx tsc --noEmit -p .
- npm run compile
- npm run compile-tests
- npx vscode-test
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->