### PR TITLE
chore: restrict Dependabot updates for VS Code pinned dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,18 @@ updates:
     labels:
       - dependencies
       - npm
+    ignore:
+      # Must stay pinned to the minimum VS Code API declared in engines.vscode.
+      # Update manually only when engines.vscode is raised.
+      - dependency-name: "@types/vscode"
+      # Safeguard: never bump anything named "vscode". Note that Dependabot
+      # only updates dependencies and never rewrites the engines field itself.
+      - dependency-name: "vscode"
+      # Must match the Node.js version of the VS Code extension host
+      # (Node 22 for VS Code 1.102+). Allow minor/patch updates within 22.x.
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       devDependencies:
         patterns:


### PR DESCRIPTION
## Summary

Add `ignore` rules to `.github/dependabot.yml` so Dependabot no longer proposes updates that would break the supported VS Code baseline:

- **`@types/vscode`**: must stay pinned to the minimum VS Code API declared in `engines.vscode` (`^1.102.0`). Update manually only when `engines.vscode` is raised.
- **`vscode`**: safeguard entry; Dependabot only updates dependencies and never rewrites the `engines` field itself.
- **`@types/node`**: block semver-major updates. Must match the Node.js version of the VS Code extension host (Node 22 for VS Code 1.102+). Minor/patch updates within 22.x remain allowed.

Follows the same approach as FreeOCD/freeocd-vscode-extension#36.

## Context

Dependabot PR #65 currently bumps `@types/vscode` to 1.125.0 as part of the devDependencies group, which would implicitly raise the minimum supported VS Code version. After this PR is merged, commenting `@dependabot recreate` on #65 will regenerate it without the ignored dependencies.

## Testing

- YAML syntax verified locally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-vscode-extension/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->